### PR TITLE
Added rumble functionality

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -28,6 +28,10 @@ import frc.robot.subsystems.Vision.VisionIOPhotonVision;
 import frc.robot.subsystems.Vision.Vision;
 import frc.robot.commands.Autos;
 
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj.Timer;
+
 public class RobotContainer {
 	private double MaxSpeed = 1.0 * TunerConstants.kSpeedAt12Volts.in(MetersPerSecond); // kSpeedAt12Volts desired
 	// top
@@ -57,7 +61,43 @@ public class RobotContainer {
 			Constants.OIConstants.kDriverControllerPort);
 	private final CommandXboxController operatorController = new CommandXboxController(
 			Constants.OIConstants.kOperatorControllerPort);
+	
+	// =============================================================
+	// Operator controller haptic feedback (rumble)
+	// =============================================================
+	//
+	// Goals:
+	//  1) Shooter-ready confirmation without looking at Shuffleboard.
+	//  2) Endgame warning at 5 seconds remaining (rule-based timing).
+	//
+	// Design principles:
+	//  - Simple, binary signals (no “always buzzing”).
+	//  - Priority: endgame warning overrides shooter-ready.
+	//  - Use FMS/DriverStation match clock (DriverStation.getMatchTime()).
+	//  - Never rumble while disabled.
+	//
+	// NOTE: All distances are meters. "Range" will be tuned on-field.
+	//
+	private static final double kShootRangeM = 4.0;           // TODO tune based on real scoring range
+	private static final double kShootRangeDeadbandM = 0.25;  // prevents on/off jitter at boundary
 
+	private static final double kRumbleShootReady = 0.60;     // steady rumble when ready to shoot (0..1)
+
+	private static final double kEndgameWarnAtSec = 5.0;      // start warning when <= 5s remaining in teleop
+	private static final double kEndgamePulseOnSec = 0.20;    // pulse pattern: on duration
+	private static final double kEndgamePulseOffSec = 0.20;   // pulse pattern: off duration
+	private static final double kRumbleEndgame = 1.00;        // endgame warning intensity (0..1)
+
+	// Cache last rumble value to avoid spamming USB updates every loop.
+	private double lastOperatorRumble = -1.0;
+
+	// Timer used ONLY for pulse pattern timing (not match timing).
+	private final Timer rumblePulseTimer = new Timer();
+	private boolean endgamePulseActive = false;
+
+	// =============================================================
+	// Other variable declarations
+	// =============================================================
 	public final CommandSwerveDrivetrain drivetrain = TunerConstants.createDrivetrain();
 	private Intake intake = null;
 	private Feeder feeder = null;
@@ -79,6 +119,11 @@ public class RobotContainer {
 		// auton = new Autos(this, drivetrain, intake, feeder, shooter, climber);
 
 		configureBindings();
+		
+		// Run rumble updater continuously.
+        // .ignoringDisable(true) allows the function to run while disabled so we can
+        // force rumble OFF and keep the pulse timer state clean.
+        Commands.run(this::updateOperatorRumble).ignoringDisable(true).schedule();
 	}
 
 	private void configureBindings() {
@@ -112,7 +157,15 @@ public class RobotContainer {
 		final var idle = new SwerveRequest.Idle();
 		RobotModeTriggers.disabled().whileTrue(
 				drivetrain.applyRequest(() -> idle).ignoringDisable(true));
-
+        
+		// OPTIONAL SAFETY: hard-stop operator rumble when disabled.
+        // (Not strictly required because updateOperatorRumble() also forces rumble off.)
+        RobotModeTriggers.disabled().onTrue(
+    		Commands.runOnce(() ->
+          		operatorController.getHID().setRumble(RumbleType.kBothRumble, 0.0)
+          	)
+        );
+		
 		// joystick.a().whileTrue(drivetrain.applyRequest(() -> brake));
 		driverController.b().whileTrue(drivetrain.applyRequest(
 				() -> point.withModuleDirection(
@@ -131,6 +184,119 @@ public class RobotContainer {
 		drivetrain.registerTelemetry(logger::telemeterize);
 	}
 
+	/*
+	 Sets operator rumble intensity (0..1).
+	 Uses a small cache to reduce repeated setRumble calls.
+	*/
+	private void setOperatorRumble(double intensity) {
+	  intensity = Math.max(0.0, Math.min(1.0, intensity));
+      
+	  // Reduce spam: only update if the value changed meaningfully.
+	  if (Math.abs(intensity - lastOperatorRumble) < 0.01) return;
+      
+	  lastOperatorRumble = intensity;
+	  operatorController.getHID().setRumble(RumbleType.kBothRumble, intensity);
+	}
+
+	/*
+	 Returns true when robot is within the current “shooting range” distance to the hub.
+	 Includes a deadband to prevent rumble chatter when hovering near the boundary.
+	*/
+	private boolean inShootRange() {
+	  double d = drivetrain.getDistToHub(); // meters
+	  return d <= (kShootRangeM - kShootRangeDeadbandM);
+	}
+
+	/*
+	 Shooter-ready is a strict condition:
+	  - in range
+	  - shooter velocity on target
+	  - tilt position on target
+	 
+	 This is intended to be a “green light” for the operator.
+	*/
+	private boolean shooterReady() {
+	  return inShootRange() && shooter.onShooterTarget() && shooter.onTiltTarget();
+	}
+
+	/*
+	 Endgame warning window based on the official match clock.
+	 
+	 We DO NOT run our own match timer.
+	 DriverStation.getMatchTime() returns seconds remaining in the current period.
+	 
+	 Returns true only during TELEOP and only when:
+	  - match time is known (>= 0)
+	  - time remaining is <= kEndgameWarnAtSec and > 0
+	*/
+	private boolean endgameWarningWindow() {
+	  if (!DriverStation.isTeleopEnabled()) return false;
+      
+	  double t = DriverStation.getMatchTime(); // seconds remaining, -1 if unknown
+	  if (t < 0.0) return false;
+      
+	  return (t <= kEndgameWarnAtSec) && (t > 0.0);
+	}
+
+	/*
+	 Simple on/off rumble pulse pattern for endgame warning.
+	 Uses rumblePulseTimer ONLY for pulse timing.
+	*/
+	private double endgamePulseIntensity() {
+	double period = kEndgamePulseOnSec + kEndgamePulseOffSec;
+	double phase = rumblePulseTimer.get() % period;
+	return (phase < kEndgamePulseOnSec) ? kRumbleEndgame : 0.0;
+	}
+
+	/**
+	 Central rumble update called continuously during robot operation.
+	 
+	 Priority order:
+	  1) Endgame warning pulses
+	  2) Shooter-ready steady rumble
+	  3) Otherwise: rumble off
+	 
+	 Safety:
+	  - Never rumble while disabled.
+	*/
+	private void updateOperatorRumble() {
+	  // Absolute safety: never rumble while disabled.
+	  if (!DriverStation.isEnabled()) {
+  		setOperatorRumble(0.0);
+
+		// Reset endgame pulse state so it starts clean on next enable.
+		endgamePulseActive = false;
+		rumblePulseTimer.stop();
+		rumblePulseTimer.reset();
+		return;
+	  }
+
+	  // Priority 1: Endgame warning pulses.
+	  if (endgameWarningWindow()) {
+		if (!endgamePulseActive) {
+		  endgamePulseActive = true;
+		  rumblePulseTimer.reset();
+		  rumblePulseTimer.start();
+		}
+        
+		setOperatorRumble(endgamePulseIntensity());
+		return;
+	  }
+
+	  // If we leave the warning window, stop/reset the pulse timer.
+	  if (endgamePulseActive) {
+		endgamePulseActive = false;
+		rumblePulseTimer.stop();
+		rumblePulseTimer.reset();
+	  }
+
+	  // Priority 2: Shooter-ready steady rumble.
+	  if (shooterReady()) {
+		setOperatorRumble(kRumbleShootReady);
+	  } else {
+		setOperatorRumble(0.0);
+	  }
+	}
 	public Command getAutonomousCommand() {
 		// Simple drive forward auton
 		final var idle = new SwerveRequest.Idle();


### PR DESCRIPTION
# Summary

Adds operator controller rumble feedback to improve match awareness without requiring visual confirmation from Shuffleboard.

This introduces two simple, high-value haptic signals:

## 1) Shooter Ready Confirmation
Steady rumble when:
- Robot is within configured shooting range
- Shooter RPM is at setpoint
- Tilt is at setpoint  

**Purpose:** Allows the operator to fire without looking away from the field.

---

## 2) Endgame Warning (5 seconds remaining)
Pulsed rumble pattern when match time ≤ 5 seconds in Teleop.

- Uses `DriverStation.getMatchTime()` (FMS clock)
- No custom match timer
- Automatically stops when match period ends

**Purpose:** Prevent missed endgame / transition timing.

---

# Priority Logic

Endgame warning overrides shooter-ready rumble.

Rumble is always forced off when the robot is disabled.

---

# Implementation Notes

- Rumble logic centralized in `RobotContainer`
- Uses FMS match clock (`DriverStation.getMatchTime()`)
- Includes deadband to prevent jitter near shooting range boundary
- Caches rumble intensity to avoid excessive HID updates
- Tunable constants isolated for easy on-field adjustment

---

# Tunable Constants

- `kShootRangeM` – Maximum scoring distance (to validate on-field)
- `kRumbleShootReady` – Steady rumble intensity
- `kEndgameWarnAtSec` – Currently set to 5 seconds
- Pulse timing values for endgame pattern

---

# No Functional Impact To

- Drive control
- Shooter ballistics logic
- Autonomous behavior

This change only adds operator feedback.