### PR TITLE
PR for 105-create-separate-constants-files-clean

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,433 +4,90 @@
 
 package frc.robot;
 
-import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
-
-import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
-import edu.wpi.first.math.trajectory.TrapezoidProfile;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.util.Color;
 
 /**
- * The Constants class provides a convenient place for teams to hold robot-wide
- * numerical or boolean
- * constants. This class should not be used for any other purpose. All constants
- * should be declared
- * globally (i.e. public static). Do not put anything functional in this class.
+ * Robot-wide shared constants only.
  *
- * <p>
- * It is advised to statically import this class (or one of its inner classes)
- * wherever the
- * constants are needed, to reduce verbosity.
+ * <p>Subsystem-specific constants should live in their matching constants files.
  */
 public final class Constants {
 
-	public static final Mode simMode = Mode.SIM;
-	public static final Mode currentMode = RobotBase.isReal() ? Mode.REAL : simMode;
+  public static final Mode simMode = Mode.SIM;
+  public static final Mode currentMode = RobotBase.isReal() ? Mode.REAL : simMode;
 
-	public static enum Mode {
-		/** Running on a real robot. */
-		REAL,
+  public enum Mode {
+    /** Running on a real robot. */
+    REAL,
 
-		/** Running a physics simulator. */
-		SIM,
+    /** Running a physics simulator. */
+    SIM,
 
 		/** Replaying from a log file. */
-		REPLAY
-	}
-
-	public static class OIConstants {
-		public static final int kDriverControllerPort = 0;
-		public static final int kOperatorControllerPort = 1;
-		public static final double kDriveDeadband = 0.05;
-	}
-
-	public static final class CANId {
-
-		public static final int kPDHCanID = 1;
-		public static final int kServoHubCanId = 2;
-
-		public static final int kClimber1CanId = 40;
-		public static final int kClimber2CanId = 41;
-		public static final int kClimber3CanId = 42;
-		public static final int kClimber4CanId = 43;
-
-		public static final int kShooterLeftCanId = 50;
-		public static final int kShooterRightCanId = 51;
-		public static final int kShooterTiltCanId = 52;
-
-		public static final int kIntakeIntakeCanId = 55;
-		public static final int kIntakeTiltCanId = 56;
-
-		public static final int kFeederCanId = 60;
-	}
-
-	public static final class DIOId {
-		public static final int kFuelAvail = 0;
-	}
-
-	public static final class AIOId {
-		public static final int kFuelSensor = 0;
-	}
-
-	public static final class MotorConstants {
-		public static final double kVortexFreeSpeedRpm = 6784;
-		public static final double kNeoFreeSpeedRpm = 5676;
-		public static final double k550FreeSpeedRpm = 11000;
-	}
-
-	public static final class ColorConstants {
-		public static final String Stopped = Color.kRed.toHexString();
-		public static final String Moving = Color.kYellow.toHexString();
-		public static final String OnTarget = Color.kGreen.toHexString();
-	}
-
-	public static final class ChassisConstants {
-		// not the maximum capable speeds of
-		// the robot, rather the allowed maximum speeds
-		public static final double kMaxSpeedMetersPerSecond = 4.8;
-		public static final double kMaxAngularSpeed = 2 * Math.PI; // radians per second
-
-		public static final double kDirectionSlewRate = 1.2; // radians per second
-		public static final double kMagnitudeSlewRate = 1.8; // percent per second (1 = 100%)
-		public static final double kRotationalSlewRate = 2.0; // percent per second (1 = 100%)
-
-		// Chassis configuration
-		public static final double kTrackWidth = Units.inchesToMeters(24.0);
-		// Distance between centers of right and left wheels on robot
-		public static final double kWheelBase = Units.inchesToMeters(24.5);
-		// Distance between front and back wheels on robot
-		public static final double kWheelRadius = Math.sqrt(2.0 * Math.pow(kWheelBase, 2)) / 2.0;
-
-		public static final SwerveDriveKinematics kDriveKinematics = new SwerveDriveKinematics(
-				new Translation2d(kWheelBase / 2, kTrackWidth / 2),
-				new Translation2d(kWheelBase / 2, -kTrackWidth / 2),
-				new Translation2d(-kWheelBase / 2, kTrackWidth / 2),
-				new Translation2d(-kWheelBase / 2, -kTrackWidth / 2));
-
-		// Angular offsets of the modules relative to the chassis in radians
-		public static final double kFrontLeftChassisAngularOffset = Math.PI / 2;
-		public static final double kFrontRightChassisAngularOffset = 0.0;
-		public static final double kBackLeftChassisAngularOffset = Math.PI;
-		public static final double kBackRightChassisAngularOffset = -Math.PI / 2;
-
-		// public static final double kFrontLeftChassisAngularOffset = 0.0;
-		// public static final double kFrontRightChassisAngularOffset = 0.0;
-		// public static final double kBackLeftChassisAngularOffset = 0.0;
-		// public static final double kBackRightChassisAngularOffset = 0.0;
-
-		public static final boolean kGyroReversed = false;
-	}
-
-	public static final class DriveConstants {
-		// Driving Parameters - Note that these are not the maximum capable speeds of
-		// the robot, rather the allowed maximum speeds
-		public static final double kMaxSpeedMetersPerSecond = 4.8;
-		public static final double kMaxAngularSpeed = 2 * Math.PI; // radians per second
-
-		// Chassis configuration
-		public static final double kTrackWidth = Units.inchesToMeters(24.0);
-		// Distance between centers of right and left wheels on robot
-		public static final double kWheelBase = Units.inchesToMeters(24.5);
-		// Distance between front and back wheels on robot
-		public static final SwerveDriveKinematics kDriveKinematics = new SwerveDriveKinematics(
-				new Translation2d(kWheelBase / 2, kTrackWidth / 2),
-				new Translation2d(kWheelBase / 2, -kTrackWidth / 2),
-				new Translation2d(-kWheelBase / 2, kTrackWidth / 2),
-				new Translation2d(-kWheelBase / 2, -kTrackWidth / 2));
-
-		// Angular offsets of the modules relative to the chassis in radians
-		public static final double kFrontLeftChassisAngularOffset = -Math.PI / 2;
-		public static final double kFrontRightChassisAngularOffset = 0;
-		public static final double kBackLeftChassisAngularOffset = Math.PI;
-		public static final double kBackRightChassisAngularOffset = Math.PI / 2;
-
-		public static final boolean kGyroReversed = false;
-
-		public static final int kDrivingMotorCurrentLimit = 50; // amps
-		public static final int kTurningMotorCurrentLimit = 20; // amps
-	}
-
-	public static final class ModuleConstants {
-		// The MAXSwerve module can be configured with one of three pinion gears: 12T,
-		// 13T, or 14T. This changes the drive speed of the module (a pinion gear with
-		// more teeth will result in a robot that drives faster).
-		public static final int kDrivingMotorPinionTeeth = 16;
-
-		// Calculations required for driving motor conversion factors and feed forward
-		public static final double kDrivingMotorFreeSpeedRps = MotorConstants.kVortexFreeSpeedRpm / 60;
-		public static final double kWheelDiameterMeters = Units.inchesToMeters(4.0); // 0.0762;
-		public static final double kWheelCircumferenceMeters = kWheelDiameterMeters * Math.PI;
-		// 45 teeth on the wheel's bevel gear, 22 teeth on the first-stage spur gear, 15
-		// teeth on the bevel pinion
-		public static final double kDrivingMotorReduction = 5.9; // (45.0 * 22) / (kDrivingMotorPinionTeeth * 15);
-		public static final double kDriveWheelFreeSpeedRps = (kDrivingMotorFreeSpeedRps * kWheelCircumferenceMeters)
-				/ kDrivingMotorReduction;
-	}
-
-	public static final class AutoConstants {
-		public static final double kMaxSpeedMetersPerSecond = 3;
-		public static final double kMaxAccelerationMetersPerSecondSquared = 3;
-		public static final double kMaxAngularSpeedRadiansPerSecond = Math.PI;
-		public static final double kMaxAngularSpeedRadiansPerSecondSquared = Math.PI;
-
-		public static final double kPXController = 1;
-		public static final double kPYController = 1;
-		public static final double kPThetaController = 1;
-
-		// Constraint for the motion profiled robot angle controller
-		public static final TrapezoidProfile.Constraints kThetaControllerConstraints = new TrapezoidProfile.Constraints(
-				kMaxAngularSpeedRadiansPerSecond, kMaxAngularSpeedRadiansPerSecondSquared);
-	}
-
-	// Gear ratios for Max and Ultra gearboxes
-	public static final class GearBox {
-		public static final double Max3 = 3.0;
-		public static final double Max4 = 4.0;
-		public static final double Max5 = 5.0;
-		public static final double Max9 = 9.0;
-
-		public static final double Ultra3 = 2.89;
-		public static final double Ultra4 = 3.61;
-		public static final double Ultra5 = 5.23;
-	}
-
-	public static final class Shooter {
-		public static final double kBallisticsCoefficient = 0.5; // Drag coefficient for projectile
-
-		public static final double kLeftZeroOffset = 0.6643792;
-		public static final boolean kLeftZeroCentered = true;
-		public static final boolean kLeftMotorInverted = false;
-		public static final boolean kLeftEncoderInverted = true;
-
-		public static final double kRightZeroOffset = 0.4019657;
-		public static final boolean kRightZeroCentered = true;
-		public static final boolean kRightMotorInverted = false;
-		public static final boolean kRightEncoderInverted = false;
-
-		public static final double kTiltZeroOffset = 0.7739866;
-		public static final boolean kTiltZeroCentered = true;
-		public static final boolean kTiltMotorInverted = true;
-		public static final boolean kTiltEncoderInverted = true;
-
-		public static final boolean kLeftEncodeWrapping = false;
-		public static final boolean kRightEncodeWrapping = false;
-		public static final boolean kTiltEncodeWrapping = false;
-		
-		// Position is returned in native units of rotations and will be multiplied by
-		// this conversion factor.
-		public static final double kShooterGearRatio = 1.0; // 1.0 is no reduction
-
-//		public static final double kShooterPositionFactor = 1.0;
-		public static final double kShooterVelocityFactor = 1.0; // Keep at 1.0 to match RPM units
-
-		// Position is returned in native units of rotations and will be multiplied by
-		// this conversion factor.
-		public static final double kTiltGearRatio = (3.0); // 3.0 is pully ratio
-
-		// IMPORTANT: Through-bore encoder is mounted on OUTPUT SHAFT, not motor shaft!
-		// Position factor converts OUTPUT shaft rotations to degrees
-		// 1 output rotation = 360 degrees (no gear ratio needed)
-		public static final double kTiltPositionFactor = 360.0 / kTiltGearRatio;  // degrees per output rotation
-		public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0;  // degrees per second
-
-		public static final double kP = 0.0002; // maxmotion 0.025;
-		public static final double kI = 0.0; // maxmotion 0.0
-		public static final double kD = 0.0; // maxmotion 0.0
-		public static final double kVelFF = 1.0 / MotorConstants.kVortexFreeSpeedRpm;	// / Constants.Shooter.kShooterGearRatio));
-
-		public static final double kMinOutput = -1.0;
-		public static final double kMaxOutput = 1.0;
-
-		// Moderate (Balanced)
-		public static final double kMaxVel = 6000.0; // RPM (~88% of Vortex max)
-		public static final double kMaxAccel = 15000.0; // RPM/sec (0.4 sec to full speed)
-		public static final double kAllowedErr = 75.0; // RPM
-
-		public static final double kPosP = 0.8;	// maxmotion 0.025;
-		public static final double kPosI = 0.0; // maxmotion 0.0
-		public static final double kPosD = 0.1; // maxmotion 0.0
-//		public static final double kPosFF = 0.0000037;
-
-		public static final double kPosMinOutput = -1.0;
-		public static final double kPosMaxOutput = 1.0;
-
-		// Moderate (Balanced)
-		public static final double kPosMaxVel = 2000.0;	//90.0; // degrees/sec (~1.1 sec for 40° travel)
-		public static final double kPosMaxAccel = 1000.0;	//180.0; // degrees/sec² (0.5 sec to max speed)
-		public static final double kPosAllowedErr = 0.1;	//0.5; // degrees
-
-		public static final IdleMode kLeftIdleMode = IdleMode.kCoast;
-		public static final IdleMode kRightIdleMode = IdleMode.kCoast;
-		public static final IdleMode kTiltIdleMode = IdleMode.kBrake;
-
-		public static final int kLeftCurrentLimit = 50; // amps
-		public static final int kRightCurrentLimit = 50; // amps
-		public static final int kTiltCurrentLimit = 50; // amps
-
-	}
-
-	public static final class Climber {
-		public static final double kServoAmpLimit = 0.5; // amps
-		public static final double kServoTimeout = 0.5; // seconds
-
-		// Motor Inversion
-		public static final boolean kClimberInverted = false;
-
-		// Idle Mode
-		public static final IdleMode kClimberIdleMode = IdleMode.kBrake;
-
-		// Current Limit
-		public static final int kClimberCurrentLimit = 50; // amps
-
-		// Abs Encoder Configs
-		public static final double kZeroOffset = 0.5; // WILL NEED ADJUSTMENT
-		public static final boolean kZeroCentered = true;
-		public static final boolean kEncoderInverted = true;
-
-		public static final double kClimberGearRatio = (GearBox.Max5 * GearBox.Max5);
-		public static final double kTiltGearRatio = (GearBox.Max5 * GearBox.Max5);
-
-		// Position is returned in native units of rotations and will be multiplied by
-		// this conversion factor.
-		public static final double kClimberPositionFactor = (1.0 * Math.PI) / kClimberGearRatio; // inches
-		public static final double kClimberVelocityFactor = kClimberPositionFactor / 60.0; // inches per second
-
-		// Position is returned in native units of rotations and will be multiplied by
-		// this conversion factor.
-		public static final double kTiltPositionFactor = 360 / kTiltGearRatio; // degrees
-		public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0; // degrees per second
-
-		// Closed loop configs
-		public static final double kPosP = 0.0; // maxmotion 0.0
-		public static final double kPosI = 0.0; // maxmotion 0.0
-		public static final double kPosD = 0.0; // maxmotion 0.0
-
-		public static final double kPosMinOutput = -0.5; // max motion -1.0
-		public static final double kPosMaxOutput = 0.5; // max motion 1.0
-
-		public static final double kClimberTolerance = 0.5; // degrees
-		public static final double kHookTolerance = 0.5; // degrees
-	}
-
-	public static final class Vision {
-		public static final double kXP = 0.6;
-		public static final double kXI = 0.0;
-		public static final double kXD = 0.0;
-		public static final double kXTolerance = 0.1;
-
-		public static final double kYP = 0.6;
-		public static final double kYI = 0.0;
-		public static final double kYD = 0.0;
-		public static final double kYTolerance = 0.1;
-
-		public static final double kRP = 0.03;
-		public static final double kRI = 0.0;
-		public static final double kRD = 0.0;
-		public static final double kRTolerance = 0.1;
-		public static final double kRMin = 0.0;
-		public static final double kRMax = 360.0;
-	}
-
-	public static final class Intake {
-//		public static final double kIntakeTolerance = 50.0; // rpms
-
-		public static final double kIntakeGearRatio = (GearBox.Max3 * GearBox.Max4);
-
-		// Position is returned in native units of rotations and will be multiplied by
-		// this conversion factor.
-		// Divide by gear ratio to convert motor shaft rotations to output shaft rotations
-		public static final double kIntakePositionFactor = 1.0 / kIntakeGearRatio;  // Output rotations per motor rotation
-		public static final double kIntakeVelocityFactor = kIntakePositionFactor;   // Output RPM per motor RPM
-
-		public static final double kIntakeZeroOffset = 0.6643792;
-		public static final boolean kIntakeZeroCentered = true;
-		public static final boolean kIntakeMotorInverted = true;
-		public static final boolean kIntakeEncoderInverted = true;
-
-		public static final IdleMode kIntakeIdleMode = IdleMode.kBrake;
-		public static final boolean kIntakeEncodeWrapping = false;
-
-		public static final double kIntakeP = 0.0002; // maxmotion 0.025;
-		public static final double kIntakeI = 0.0; // maxmotion 0.0
-		public static final double kIntakeD = 0.0; // maxmotion 0.0
-		public static final double kVelFF = 1.0 / (MotorConstants.kNeoFreeSpeedRpm / Constants.Intake.kIntakeGearRatio);
-		public static final double kIntakeMinOutput = -1.0;
-		public static final double kIntakeMaxOutput = 1.0;
-
-		// Aggressive (Fast, Less Smooth)
-		public static final double kIntakeMaxVel = 5000.0; // RPM (~88% of NEO max)
-		public static final double kIntakeMaxAccel = 16000.0; // RPM/sec (0.3125 sec to full speed)
-		public static final double kIntakeAllowedErr = 50.0; // RPM
-
-		public static final int kIntakeCurrentLimit = 50; // amps
-
-//		public static final double kTiltTolerance = 1.0; // degrees
-
-		public static final double kTiltGearRatio = (GearBox.Max5 * GearBox.Max5);
-
-		// IMPORTANT: Through-bore encoder is mounted on OUTPUT SHAFT, not motor shaft!
-		// Position factor converts OUTPUT shaft rotations to degrees
-		// 1 output rotation = 360 degrees (no gear ratio needed)
-		public static final double kTiltPositionFactor = 360.0;  // degrees per output rotation
-		public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0; // degrees per second
-
-		public static final double kTiltZeroOffset = 0.4019657;
-		public static final boolean kTiltZeroCentered = true;
-		public static final boolean kTiltMotorInverted = false;
-		public static final boolean kTiltEncoderInverted = false;
-
-		public static final double kTiltP = 0.8; // maxmotion 0.025;
-		public static final double kTiltI = 0.0; // maxmotion 0.0
-		public static final double kTiltD = 0.1; // maxmotion 0.0
-		public static final double kTiltMinOutput = -1.0;
-		public static final double kTiltMaxOutput = 1.0;
-
-		// Moderate (Balanced)
-		public static final double kTiltMaxVel = 120.0; // degrees/sec (~1.7 sec for full 80° travel)
-		public static final double kTiltMaxAccel = 240.0; // degrees/sec² (0.5 sec to max speed)
-		public static final double kTiltAllowedErr = 1.0; // degrees
-
-		public static final IdleMode kTiltIdleMode = IdleMode.kBrake;
-		public static final boolean kTiltEncodeWrapping = false;
-
-		public static final int kTiltCurrentLimit = 50; // amps
-	}
-
-	public static final class Feeder {
-//		public static final double kTolerance = 75.0; // RPMs
-
-		public static final double kFeederZeroOffset = 0.6643792;
-		public static final boolean kFeederZeroCentered = true;
-		public static final boolean kFeederMotorInverted = true;
-		public static final boolean kFeederEncoderInverted = false;
-
-		public static final boolean kFeederEncodeWrapping = false;
-		public static final IdleMode kFeederIdleMode = IdleMode.kBrake;
-
-		public static final double kFeederGearRatio = (GearBox.Max3 * GearBox.Max4);
-
-		// Position is returned in native units of rotations and will be multiplied by
-		// this conversion factor.
-		// Divide by gear ratio to convert motor shaft rotations to output shaft rotations
-		public static final double kFeederPositionFactor = 1.0 / kFeederGearRatio;  // Output rotations per motor rotation
-		public static final double kFeederVelocityFactor = kFeederPositionFactor;   // Output RPM per motor RPM
-
-		public static final double kFeederP = 0.0002;
-		public static final double kFeederI = 0.0;// 000001;
-		public static final double kFeederD = 0.0;// 1;
-		public static final double kFeederVelFF = 1.0 / (MotorConstants.kNeoFreeSpeedRpm / Constants.Feeder.kFeederGearRatio);// 0000037;
-
-		public static final double kFeederMinOutput = -1.0;
-		public static final double kFeederMaxOutput = 1.0;
-
-		// Moderate (Balanced)
-		public static final double kFeederMaxVel = 4000.0; // RPM (~70% of NEO max)
-		public static final double kFeederMaxAccel = 10000.0; // RPM/sec (0.4 sec to full speed)
-		public static final double kFeederAllowedErr = 75.0; // RPM
-
-		public static final int kFeederCurrentLimit = 50; // amps
-	}
+    REPLAY
+  }
+
+  public static final class OIConstants {
+    public static final int kDriverControllerPort = 0;
+    public static final int kOperatorControllerPort = 1;
+    public static final double kDriveDeadband = 0.05;
+
+    private OIConstants() {}
+  }
+
+  public static final class CANId {
+    public static final int kPDHCanID = 1;
+    public static final int kServoHubCanId = 2;
+
+    public static final int kClimber1CanId = 40;
+    public static final int kClimber2CanId = 41;
+    public static final int kClimber3CanId = 42;
+    public static final int kClimber4CanId = 43;
+
+    public static final int kShooterLeftCanId = 50;
+    public static final int kShooterRightCanId = 51;
+    public static final int kShooterTiltCanId = 52;
+
+    public static final int kIntakeIntakeCanId = 55;
+    public static final int kIntakeTiltCanId = 56;
+
+    public static final int kFeederCanId = 60;
+
+    private CANId() {}
+  }
+
+  public static final class MotorConstants {
+    public static final double kVortexFreeSpeedRpm = 6784;
+    public static final double kNeoFreeSpeedRpm = 5676;
+    public static final double k550FreeSpeedRpm = 11000;
+
+    private MotorConstants() {}
+  }
+
+  public static final class ColorConstants {
+    public static final String Stopped = Color.kRed.toHexString();
+    public static final String Moving = Color.kYellow.toHexString();
+    public static final String OnTarget = Color.kGreen.toHexString();
+
+    private ColorConstants() {}
+  }
+
+  // Gear ratios shared across multiple subsystem constants files.
+  
+  // Gear ratios for Max and Ultra gearboxes
+  public static final class GearBox {
+    public static final double Max3 = 3.0;
+    public static final double Max4 = 4.0;
+    public static final double Max5 = 5.0;
+    public static final double Max9 = 9.0;
+
+    public static final double Ultra3 = 2.89;
+    public static final double Ultra4 = 3.61;
+    public static final double Ultra5 = 5.23;
+
+    private GearBox() {}
+  }
+
+  private Constants() {}
 }

--- a/src/main/java/frc/robot/constants/ClimberConstants.java
+++ b/src/main/java/frc/robot/constants/ClimberConstants.java
@@ -1,0 +1,56 @@
+package frc.robot.constants;
+
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+
+import frc.robot.Constants;
+
+public final class ClimberConstants {
+  public static final int kServoHubCanId = Constants.CANId.kServoHubCanId;
+  public static final int kClimber1CanId = Constants.CANId.kClimber1CanId;
+  public static final int kClimber2CanId = Constants.CANId.kClimber2CanId;
+  public static final int kClimber3CanId = Constants.CANId.kClimber3CanId;
+  public static final int kClimber4CanId = Constants.CANId.kClimber4CanId;
+
+  public static final double kServoAmpLimit = 0.5; // amps
+  public static final double kServoTimeout = 0.5; // seconds
+
+  // Motor Inversion
+  public static final boolean kClimberInverted = false;
+
+  // Idle Mode
+  public static final IdleMode kClimberIdleMode = IdleMode.kBrake;
+
+  // Current Limit
+  public static final int kClimberCurrentLimit = 50; // amps
+
+  // Abs Encoder Configs
+  public static final double kZeroOffset = 0.5;
+  public static final boolean kZeroCentered = true;
+  public static final boolean kEncoderInverted = true;
+
+  public static final double kClimberGearRatio = Constants.GearBox.Max5 * Constants.GearBox.Max5;
+  public static final double kTiltGearRatio = Constants.GearBox.Max5 * Constants.GearBox.Max5;
+
+  // Position is returned in native units of rotations and will be multiplied by
+	// this conversion factor.
+  public static final double kClimberPositionFactor = (1.0 * Math.PI) / kClimberGearRatio; // inches
+  public static final double kClimberVelocityFactor = kClimberPositionFactor / 60.0; // inches per second
+  
+	// Position is returned in native units of rotations and will be multiplied by
+	// this conversion factor.
+  public static final double kTiltPositionFactor = 360 / kTiltGearRatio;
+  public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0;
+
+  // Closed loop configs
+  public static final double kPosP = 0.0; // maxmotion 0.0
+  public static final double kPosI = 0.0; // maxmotion 0.0
+  public static final double kPosD = 0.0; // maxmotion 0.0
+
+  public static final double kPosMinOutput = -0.5; // max motion -1.0
+  public static final double kPosMaxOutput = 0.5; // max motion 1.0
+
+  public static final double kClimberTolerance = 0.5; // degrees
+  public static final double kHookTolerance = 0.5; // degrees
+
+  private ClimberConstants() {}
+}

--- a/src/main/java/frc/robot/constants/CommandSwerveDrivetrainConstants.java
+++ b/src/main/java/frc/robot/constants/CommandSwerveDrivetrainConstants.java
@@ -1,0 +1,33 @@
+package frc.robot.constants;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+
+public final class CommandSwerveDrivetrainConstants {
+  public static final double kSimLoopPeriod = 0.004; // 4 ms
+
+  /* Blue alliance sees forward as 0 degrees (toward red alliance wall) */
+  public static final Rotation2d kBlueAlliancePerspectiveRotation = Rotation2d.kZero;
+
+  /* Red alliance sees forward as 180 degrees (toward blue alliance wall) */
+  public static final Rotation2d kRedAlliancePerspectiveRotation = Rotation2d.k180deg;
+
+  /* Hub pose for 2026  */
+  public static final Pose2d kHubPose =
+      new Pose2d(new Translation2d(4.660, 4.118), Rotation2d.fromDegrees(180.0));
+
+  /* This is the blue side starting pose. AutoBuilder will mirror for red. */
+  public static final Pose2d kStartPose =
+      new Pose2d(new Translation2d(3.45, 2.75), Rotation2d.fromDegrees(42.5));
+
+  public static final double kTranslationPidP = 5.0;
+  public static final double kTranslationPidI = 0.0;
+  public static final double kTranslationPidD = 0.0;
+
+  public static final double kRotationPidP = 5.0;
+  public static final double kRotationPidI = 0.0;
+  public static final double kRotationPidD = 0.0;
+
+  private CommandSwerveDrivetrainConstants() {}
+}

--- a/src/main/java/frc/robot/constants/FeederConstants.java
+++ b/src/main/java/frc/robot/constants/FeederConstants.java
@@ -1,0 +1,46 @@
+package frc.robot.constants;
+
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+
+import frc.robot.Constants;
+
+public final class FeederConstants {
+  public static final int kFeederCanId = Constants.CANId.kFeederCanId;
+  public static final int kFuelSensorChannel = 0;
+  public static final double kFeederMotorFreeSpeedRpm = Constants.MotorConstants.kNeoFreeSpeedRpm;
+
+//	public static final double kTolerance = 75.0; // RPMs
+
+  public static final double kFeederZeroOffset = 0.6643792;
+  public static final boolean kFeederZeroCentered = true;
+  public static final boolean kFeederMotorInverted = true;
+  public static final boolean kFeederEncoderInverted = false;
+
+  public static final boolean kFeederEncodeWrapping = false;
+  public static final IdleMode kFeederIdleMode = IdleMode.kBrake;
+
+  public static final double kFeederGearRatio = (Constants.GearBox.Max3 * Constants.GearBox.Max4);
+  
+  // Position is returned in native units of rotations and will be multiplied by
+  // this conversion factor.
+  // Divide by gear ratio to convert motor shaft rotations to output shaft rotations
+  public static final double kFeederPositionFactor = 1.0 / kFeederGearRatio; // Output rotations per motor rotation
+  public static final double kFeederVelocityFactor = kFeederPositionFactor; // Output RPM per motor RPM
+
+  public static final double kFeederP = 0.0002;
+  public static final double kFeederI = 0.0; // 000001;
+  public static final double kFeederD = 0.0; // 1;
+  public static final double kFeederVelFF = 1.0 / (kFeederMotorFreeSpeedRpm / kFeederGearRatio); // 0000037;
+
+  public static final double kFeederMinOutput = -1.0;
+  public static final double kFeederMaxOutput = 1.0;
+
+  // Moderate (Balanced)
+  public static final double kFeederMaxVel = 4000.0; // RPM (~70% of NEO max)
+  public static final double kFeederMaxAccel = 10000.0; // RPM/sec (0.4 sec to full speed)
+  public static final double kFeederAllowedErr = 75.0; // RPM
+  
+  public static final int kFeederCurrentLimit = 50; // amps
+
+  private FeederConstants() {}
+}

--- a/src/main/java/frc/robot/constants/IntakeConstants.java
+++ b/src/main/java/frc/robot/constants/IntakeConstants.java
@@ -1,0 +1,77 @@
+package frc.robot.constants;
+
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+
+import frc.robot.Constants;
+
+public final class IntakeConstants {
+  public static final int kIntakeMotorCanId = Constants.CANId.kIntakeIntakeCanId;
+  public static final int kTiltMotorCanId = Constants.CANId.kIntakeTiltCanId;
+  public static final double kIntakeMotorFreeSpeedRpm = Constants.MotorConstants.kNeoFreeSpeedRpm;
+
+//	public static final double kIntakeTolerance = 50.0; // rpms
+  public static final double kIntakeGearRatio = (Constants.GearBox.Max3 * Constants.GearBox.Max4);
+
+  
+	// Position is returned in native units of rotations and will be multiplied by
+	// this conversion factor.
+	// Divide by gear ratio to convert motor shaft rotations to output shaft rotations
+  public static final double kIntakePositionFactor = 1.0 / kIntakeGearRatio; // Output rotations per motor rotation
+  public static final double kIntakeVelocityFactor = kIntakePositionFactor; // Output RPM per motor RPM
+
+  public static final double kIntakeZeroOffset = 0.6643792;
+  public static final boolean kIntakeZeroCentered = true;
+  public static final boolean kIntakeMotorInverted = true;
+  public static final boolean kIntakeEncoderInverted = true;
+
+  public static final IdleMode kIntakeIdleMode = IdleMode.kBrake;
+  public static final boolean kIntakeEncodeWrapping = false;
+
+  public static final double kIntakeP = 0.0002; // maxmotion 0.025;
+  public static final double kIntakeI = 0.0; // maxmotion 0.0
+  public static final double kIntakeD = 0.0; // maxmotion 0.0
+  public static final double kVelFF = 1.0 / (kIntakeMotorFreeSpeedRpm / kIntakeGearRatio);
+  public static final double kIntakeMinOutput = -1.0;
+  public static final double kIntakeMaxOutput = 1.0;
+
+  // Aggressive (Fast, Less Smooth)
+  public static final double kIntakeMaxVel = 5000.0; // RPM (~88% of NEO max)
+  public static final double kIntakeMaxAccel = 16000.0; // RPM/sec (0.3125 sec to full speed)
+  public static final double kIntakeAllowedErr = 50.0; // RPM
+
+  public static final int kIntakeCurrentLimit = 50; // amps
+
+//	public static final double kTiltTolerance = 1.0; // degrees
+
+  public static final double kTiltGearRatio = (Constants.GearBox.Max5 * Constants.GearBox.Max5);
+
+  
+	// IMPORTANT: Through-bore encoder is mounted on OUTPUT SHAFT, not motor shaft!
+	// Position factor converts OUTPUT shaft rotations to degrees
+	// 1 output rotation = 360 degrees (no gear ratio needed)
+  public static final double kTiltPositionFactor = 360.0; // degrees per output rotation
+  public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0; // degrees per second
+
+  public static final double kTiltZeroOffset = 0.4019657;
+  public static final boolean kTiltZeroCentered = true;
+  public static final boolean kTiltMotorInverted = false;
+  public static final boolean kTiltEncoderInverted = false;
+
+  public static final double kTiltP = 0.8; // maxmotion 0.025;
+  public static final double kTiltI = 0.0; // maxmotion 0.0
+  public static final double kTiltD = 0.1; // maxmotion 0.0
+  public static final double kTiltMinOutput = -1.0;
+  public static final double kTiltMaxOutput = 1.0;
+
+  // Moderate (Balanced)
+  public static final double kTiltMaxVel = 120.0; // degrees/sec (~1.7 sec for full 80° travel)
+  public static final double kTiltMaxAccel = 240.0; // degrees/sec² (0.5 sec to max speed)
+  public static final double kTiltAllowedErr = 1.0; // degrees
+
+  public static final IdleMode kTiltIdleMode = IdleMode.kBrake;
+  public static final boolean kTiltEncodeWrapping = false;
+  
+  public static final int kTiltCurrentLimit = 50; // amps
+
+  private IntakeConstants() {}
+}

--- a/src/main/java/frc/robot/constants/ShooterConstants.java
+++ b/src/main/java/frc/robot/constants/ShooterConstants.java
@@ -1,0 +1,86 @@
+package frc.robot.constants;
+
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+
+import frc.robot.Constants;
+
+public final class ShooterConstants {
+  public static final int kLeftShooterCanId = Constants.CANId.kShooterLeftCanId;
+  public static final int kRightShooterCanId = Constants.CANId.kShooterRightCanId;
+  public static final int kTiltMotorCanId = Constants.CANId.kShooterTiltCanId;
+  public static final double kShooterMotorFreeSpeedRpm = Constants.MotorConstants.kVortexFreeSpeedRpm;
+
+  public static final double kBallisticsCoefficient = 0.5; // Drag coefficient for projectile
+
+  public static final double kLeftZeroOffset = 0.6643792;
+  public static final boolean kLeftZeroCentered = true;
+  public static final boolean kLeftMotorInverted = false;
+  public static final boolean kLeftEncoderInverted = true;
+
+  public static final double kRightZeroOffset = 0.4019657;
+  public static final boolean kRightZeroCentered = true;
+  public static final boolean kRightMotorInverted = false;
+  public static final boolean kRightEncoderInverted = false;
+
+  public static final double kTiltZeroOffset = 0.7739866;
+  public static final boolean kTiltZeroCentered = true;
+  public static final boolean kTiltMotorInverted = true;
+  public static final boolean kTiltEncoderInverted = true;
+
+  public static final boolean kLeftEncodeWrapping = false;
+  public static final boolean kRightEncodeWrapping = false;
+  public static final boolean kTiltEncodeWrapping = false;
+
+  // Position is returned in native units of rotations and will be multiplied by
+	// this conversion factor.
+  public static final double kShooterGearRatio = 1.0; // 1.0 is no reduction
+
+//	public static final double kShooterPositionFactor = 1.0;
+  public static final double kShooterVelocityFactor = 1.0; // Keep at 1.0 to match RPM units
+
+  // Position is returned in native units of rotations and will be multiplied by
+	// this conversion factor.
+  public static final double kTiltGearRatio = 3.0;  // 3.0 is pully ratio
+
+	// IMPORTANT: Through-bore encoder is mounted on OUTPUT SHAFT, not motor shaft!
+	// Position factor converts OUTPUT shaft rotations to degrees
+	// 1 output rotation = 360 degrees (no gear ratio needed)
+  public static final double kTiltPositionFactor = 360.0 / kTiltGearRatio; // degrees per output rotation
+  public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0; // degrees per second
+
+  public static final double kP = 0.0002; // maxmotion 0.025;
+  public static final double kI = 0.0; // maxmotion 0.0
+  public static final double kD = 0.0; // maxmotion 0.0
+  public static final double kVelFF = 1.0 / kShooterMotorFreeSpeedRpm;
+
+  public static final double kMinOutput = -1.0;
+  public static final double kMaxOutput = 1.0;
+
+  // Moderate (Balanced)
+  public static final double kMaxVel = 6000.0; // RPM (~88% of Vortex max)
+  public static final double kMaxAccel = 15000.0; // maxmotion 0.0
+  public static final double kAllowedErr = 75.0; // maxmotion 0.0
+	public static final double kPosFF = 0.0000037;
+
+  public static final double kPosP = 0.8;
+  public static final double kPosI = 0.0;
+  public static final double kPosD = 0.1;
+
+  public static final double kPosMinOutput = -1.0;
+  public static final double kPosMaxOutput = 1.0;
+
+  // Moderate (Balanced)
+  public static final double kPosMaxVel = 2000.0; //90.0; // degrees/sec (~1.1 sec for 40° travel)
+  public static final double kPosMaxAccel = 1000.0; //180.0; // degrees/sec² (0.5 sec to max speed)
+  public static final double kPosAllowedErr = 0.1; //0.5; // degrees
+
+  public static final IdleMode kLeftIdleMode = IdleMode.kCoast;
+  public static final IdleMode kRightIdleMode = IdleMode.kCoast;
+  public static final IdleMode kTiltIdleMode = IdleMode.kBrake;
+  
+  public static final int kLeftCurrentLimit = 50; // amps
+  public static final int kRightCurrentLimit = 50; // amps
+  public static final int kTiltCurrentLimit = 50; // amps
+
+  private ShooterConstants() {}
+}

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -29,6 +29,7 @@ import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.constants.ClimberConstants;
 import frc.robot.utils.Library;
 import frc.robot.utils.SparkMaxSimulation;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -39,16 +40,16 @@ public class Climber extends SubsystemBase {
   // Define Climber Motors and Servos
   // ==============================================================
   private final SparkMax climber1 = new SparkMax(
-      Constants.CANId.kClimber1CanId, MotorType.kBrushless);
+      ClimberConstants.kClimber1CanId, MotorType.kBrushless);
 
   private final SparkMax climber2 = new SparkMax(
-      Constants.CANId.kClimber2CanId, MotorType.kBrushless);
+      ClimberConstants.kClimber2CanId, MotorType.kBrushless);
 
   private final SparkMax climber3 = new SparkMax(
-      Constants.CANId.kClimber3CanId, MotorType.kBrushless);
+      ClimberConstants.kClimber3CanId, MotorType.kBrushless);
 
   private final SparkMax climber4 = new SparkMax(
-      Constants.CANId.kClimber4CanId, MotorType.kBrushless);
+      ClimberConstants.kClimber4CanId, MotorType.kBrushless);
 
   private final SparkMaxConfig climber1Config = new SparkMaxConfig();
   private final SparkMaxConfig climber2Config = new SparkMaxConfig();
@@ -71,7 +72,7 @@ public class Climber extends SubsystemBase {
   // private final AbsoluteEncoder climber4AbsEncoder =
   // climber4.getAbsoluteEncoder();
 
-  private final ServoHub servoHub = new ServoHub(Constants.CANId.kServoHubCanId);
+  private final ServoHub servoHub = new ServoHub(ClimberConstants.kServoHubCanId);
   private final ServoChannel leftHook = servoHub.getServoChannel(ChannelId.kChannelId0);
   private final ServoChannel rightHook = servoHub.getServoChannel(ChannelId.kChannelId1);
 
@@ -157,25 +158,25 @@ public class Climber extends SubsystemBase {
 
     // Climbing Motor Configs 1-4
     climber1Config
-        .inverted(Constants.Climber.kClimberInverted)
-        .idleMode(Constants.Climber.kClimberIdleMode)
-        .smartCurrentLimit(Constants.Climber.kClimberCurrentLimit);
+        .inverted(ClimberConstants.kClimberInverted)
+        .idleMode(ClimberConstants.kClimberIdleMode)
+        .smartCurrentLimit(ClimberConstants.kClimberCurrentLimit);
     climber1Config.absoluteEncoder
-        .zeroOffset(Constants.Climber.kZeroOffset)
-        .zeroCentered(Constants.Climber.kZeroCentered)
-        .inverted(Constants.Climber.kEncoderInverted)
-        .positionConversionFactor(Constants.Climber.kTiltPositionFactor)
-        .velocityConversionFactor(Constants.Climber.kTiltVelocityFactor);
+        .zeroOffset(ClimberConstants.kZeroOffset)
+        .zeroCentered(ClimberConstants.kZeroCentered)
+        .inverted(ClimberConstants.kEncoderInverted)
+        .positionConversionFactor(ClimberConstants.kTiltPositionFactor)
+        .velocityConversionFactor(ClimberConstants.kTiltVelocityFactor);
     climber1Config.closedLoop
         .feedbackSensor(FeedbackSensor.kAbsoluteEncoder)
-        .p(Constants.Climber.kPosP)
-        .i(Constants.Climber.kPosI)
-        .d(Constants.Climber.kPosD)
-        .outputRange(Constants.Climber.kPosMinOutput, Constants.Climber.kPosMaxOutput);
+        .p(ClimberConstants.kPosP)
+        .i(ClimberConstants.kPosI)
+        .d(ClimberConstants.kPosD)
+        .outputRange(ClimberConstants.kPosMinOutput, ClimberConstants.kPosMaxOutput);
 
-    climber2Config.follow(Constants.CANId.kClimber1CanId); // Mimics climber1
-    climber3Config.follow(Constants.CANId.kClimber1CanId);
-    climber4Config.follow(Constants.CANId.kClimber1CanId);
+    climber2Config.follow(ClimberConstants.kClimber1CanId); // Mimics climber1
+    climber3Config.follow(ClimberConstants.kClimber1CanId);
+    climber4Config.follow(ClimberConstants.kClimber1CanId);
 
     climber1.configure(climber1Config,
         com.revrobotics.ResetMode.kNoResetSafeParameters,
@@ -248,7 +249,7 @@ public class Climber extends SubsystemBase {
       climber1Sim = SparkMaxSimulation.createPositionSim(
           climber1,
           DCMotor.getNEO(1),
-          Constants.Climber.kClimberGearRatio,
+          ClimberConstants.kClimberGearRatio,
           0.3, // arm length in meters
           ClimberSP.BOT.getValue(), // min position
           ClimberSP.TOP.getValue(), // max position
@@ -287,8 +288,8 @@ public class Climber extends SubsystemBase {
         interrupted -> this.setHook(leftHook, HookSP.STOP),
         // Is finished
         // Timer has expired and amps are higher than threshold
-        () -> ((this.getChannelAmps(leftHook) >= Constants.Climber.kServoAmpLimit)
-            && timer.hasElapsed(Constants.Climber.kServoTimeout)));
+        () -> ((this.getChannelAmps(leftHook) >= ClimberConstants.kServoAmpLimit)
+            && timer.hasElapsed(ClimberConstants.kServoTimeout)));
   }
 
   public Command stowRightHook() {
@@ -310,22 +311,22 @@ public class Climber extends SubsystemBase {
         interrupted -> this.setHook(rightHook, HookSP.STOP),
         // Is finished
         // Timer has expired and amps are higher than threshold
-        () -> ((this.getChannelAmps(rightHook) >= Constants.Climber.kServoAmpLimit)
-            && timer.hasElapsed(Constants.Climber.kServoTimeout)));
+        () -> ((this.getChannelAmps(rightHook) >= ClimberConstants.kServoAmpLimit)
+            && timer.hasElapsed(ClimberConstants.kServoTimeout)));
   }
 
   public Command stowLeftHook1() {
     return Commands.startEnd(
         () -> this.setHook(leftHook, HookSP.STOW),
         () -> this.setHook(leftHook, HookSP.STOP))
-        .until(() -> this.getChannelAmps(leftHook) >= Constants.Climber.kServoAmpLimit);
+        .until(() -> this.getChannelAmps(leftHook) >= ClimberConstants.kServoAmpLimit);
   }
 
   public Command stowRightHook1() {
     return Commands.startEnd(
         () -> this.setHook(rightHook, HookSP.STOW),
         () -> this.setHook(rightHook, HookSP.STOP))
-        .until(() -> this.getChannelAmps(rightHook) >= Constants.Climber.kServoAmpLimit);
+        .until(() -> this.getChannelAmps(rightHook) >= ClimberConstants.kServoAmpLimit);
   }
 
   public Command stowHooks() {
@@ -410,7 +411,7 @@ public class Climber extends SubsystemBase {
   }
 
   public boolean onClimberTarget() {
-    return Math.abs(getClimberPos() - getClimberSP().getValue()) < Constants.Climber.kClimberTolerance;
+    return Math.abs(getClimberPos() - getClimberSP().getValue()) < ClimberConstants.kClimberTolerance;
   }
   // End of Climber Methods
   // Start of Servo Methods
@@ -428,7 +429,7 @@ public class Climber extends SubsystemBase {
   }
 
   public boolean onHookTarget() {
-    return Math.abs(getHookSpd() - getHookSP().getSpd()) < Constants.Climber.kHookTolerance;
+    return Math.abs(getHookSpd() - getHookSP().getSpd()) < ClimberConstants.kHookTolerance;
   }
 
   public void setHook(ServoChannel channel, HookSP sp) {

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -45,6 +45,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants.CANId;
+import frc.robot.constants.CommandSwerveDrivetrainConstants;
 import frc.robot.generated.TunerConstants;
 import frc.robot.generated.TunerConstants.TunerSwerveDrivetrain;
 import frc.robot.utils.Library;
@@ -57,14 +58,9 @@ import frc.robot.utils.Library;
  * https://v6.docs.ctr-electronics.com/en/stable/docs/tuner/tuner-swerve/index.html
  */
 public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Subsystem {
-    private static final double kSimLoopPeriod = 0.004; // 4 ms
     private Notifier m_simNotifier = null;
     private double m_lastSimTime;
 
-    /* Blue alliance sees forward as 0 degrees (toward red alliance wall) */
-    private static final Rotation2d kBlueAlliancePerspectiveRotation = Rotation2d.kZero;
-    /* Red alliance sees forward as 180 degrees (toward blue alliance wall) */
-    private static final Rotation2d kRedAlliancePerspectiveRotation = Rotation2d.k180deg;
     /* Keep track if we've ever applied the operator perspective before or not */
     private boolean m_hasAppliedOperatorPerspective = false;
 
@@ -146,14 +142,6 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
     // Create field and pose related vars
     private final Field2d m_field = new Field2d();
 
-    private final Pose2d hubPose = new Pose2d(
-            new Translation2d(4.660, 4.118),
-            Rotation2d.fromDegrees(180.0)); // Hub pose for 2026
-    private final Pose2d startPose = new Pose2d( // This is the blue side starting pose. AutoBuilder will mirror for
-                                                 // red.
-            new Translation2d(3.45, 2.75),
-            Rotation2d.fromDegrees(42.5));
-
     public Pose2d currPose = null;
     public Rotation2d bearingToHub = null;
     public double distToHub = 0.0;
@@ -197,7 +185,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             startSimThread();
         }
 
-        m_field.setRobotPose(startPose);
+        m_field.setRobotPose(CommandSwerveDrivetrainConstants.kStartPose);
         SmartDashboard.putData("Field", m_field);
 
         configPDH();
@@ -230,7 +218,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             startSimThread();
         }
 
-        m_field.setRobotPose(startPose);
+        m_field.setRobotPose(CommandSwerveDrivetrainConstants.kStartPose);
         SmartDashboard.putData("Field", m_field);
 
         configPDH();
@@ -278,7 +266,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             startSimThread();
         }
 
-        m_field.setRobotPose(startPose);
+        m_field.setRobotPose(CommandSwerveDrivetrainConstants.kStartPose);
         SmartDashboard.putData("Field", m_field);
 
         configPDH();
@@ -337,8 +325,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             DriverStation.getAlliance().ifPresent(allianceColor -> {
                 setOperatorPerspectiveForward(
                         allianceColor == Alliance.Red
-                                ? kRedAlliancePerspectiveRotation
-                                : kBlueAlliancePerspectiveRotation);
+                                ? CommandSwerveDrivetrainConstants.kRedAlliancePerspectiveRotation
+                                : CommandSwerveDrivetrainConstants.kBlueAlliancePerspectiveRotation);
                 m_hasAppliedOperatorPerspective = true;
             });
         }
@@ -400,8 +388,14 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                                                                       // individual module feedforwards
                 new PPHolonomicDriveController( // PPHolonomicController is the built in path following controller for
                                                 // holonomic drive trains
-                        new PIDConstants(5.0, 0.0, 0.0), // Translation PID constants
-                        new PIDConstants(5.0, 0.0, 0.0) // Rotation PID constants
+                        new PIDConstants(
+                                CommandSwerveDrivetrainConstants.kTranslationPidP,
+                                CommandSwerveDrivetrainConstants.kTranslationPidI,
+                                CommandSwerveDrivetrainConstants.kTranslationPidD), // Translation PID constants
+                        new PIDConstants(
+                                CommandSwerveDrivetrainConstants.kRotationPidP,
+                                CommandSwerveDrivetrainConstants.kRotationPidI,
+                                CommandSwerveDrivetrainConstants.kRotationPidD) // Rotation PID constants
                 ),
                 config, // The robot configuration
                 () -> {
@@ -494,11 +488,11 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
     }
 
     public Rotation2d getBearingToHub() {
-        return ((getPose().getTranslation().minus(hubPose.getTranslation())).getAngle().plus(new Rotation2d(Math.PI)));
+        return ((getPose().getTranslation().minus(CommandSwerveDrivetrainConstants.kHubPose.getTranslation())).getAngle().plus(new Rotation2d(Math.PI)));
     }
 
     public double getDistToHub() {
-        return hubPose.getTranslation().getDistance(getPose().getTranslation());
+        return CommandSwerveDrivetrainConstants.kHubPose.getTranslation().getDistance(getPose().getTranslation());
     }
 
     public double getHeading() {
@@ -517,7 +511,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             /* use the measured time delta, get battery voltage from WPILib */
             updateSimState(deltaTime, RobotController.getBatteryVoltage());
         });
-        m_simNotifier.startPeriodic(kSimLoopPeriod);
+        m_simNotifier.startPeriodic(CommandSwerveDrivetrainConstants.kSimLoopPeriod);
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/Feeder.java
+++ b/src/main/java/frc/robot/subsystems/Feeder.java
@@ -23,6 +23,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.constants.FeederConstants;
 import frc.robot.utils.Library;
 import frc.robot.utils.SparkMaxSimulation;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -32,7 +33,7 @@ public class Feeder extends SubsystemBase {
   // Define Feeder Motor
   // ==============================================================
   private final SparkMax feeder = new SparkMax(
-      Constants.CANId.kFeederCanId, MotorType.kBrushless);
+      FeederConstants.kFeederCanId, MotorType.kBrushless);
 
   private final SparkMaxConfig feederConfig = new SparkMaxConfig();
 
@@ -46,7 +47,7 @@ public class Feeder extends SubsystemBase {
   // ==============================================================
   // Define trigger inputs
   // =============================================================
-  private final AnalogInput fuelSensor = new AnalogInput(Constants.AIOId.kFuelSensor);
+  private final AnalogInput fuelSensor = new AnalogInput(FeederConstants.kFuelSensorChannel);
 
   // ==============================================================
   // Define motor vel enum
@@ -80,7 +81,7 @@ public class Feeder extends SubsystemBase {
      */
     public double getVel(boolean rpm) {
       if (rpm) {
-        return Library.pctToRpm(pct, Constants.MotorConstants.kNeoFreeSpeedRpm);
+        return Library.pctToRpm(pct, FeederConstants.kFeederMotorFreeSpeedRpm);
       } else {
         return pct;
       }
@@ -133,25 +134,25 @@ public class Feeder extends SubsystemBase {
     System.out.println("+++++ Starting Feeder Constructor +++++");
     // Configure Feeder motor
     feederConfig
-        .idleMode(Constants.Feeder.kFeederIdleMode)
-        .smartCurrentLimit(Constants.Feeder.kFeederCurrentLimit)
-        .inverted(Constants.Feeder.kFeederMotorInverted);
+        .idleMode(FeederConstants.kFeederIdleMode)
+        .smartCurrentLimit(FeederConstants.kFeederCurrentLimit)
+        .inverted(FeederConstants.kFeederMotorInverted);
     feederConfig.encoder
-//        .positionConversionFactor(Constants.Feeder.kFeederPositionFactor)
-        .velocityConversionFactor(Constants.Feeder.kFeederVelocityFactor);
+//        .positionConversionFactor(FeederConstants.kFeederPositionFactor)
+        .velocityConversionFactor(FeederConstants.kFeederVelocityFactor);
     feederConfig.closedLoop
         .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
-        .p(Constants.Feeder.kFeederP)
-        .i(Constants.Feeder.kFeederI)
-        .d(Constants.Feeder.kFeederD)
-        .outputRange(Constants.Feeder.kFeederMinOutput, Constants.Feeder.kFeederMaxOutput);
+        .p(FeederConstants.kFeederP)
+        .i(FeederConstants.kFeederI)
+        .d(FeederConstants.kFeederD)
+        .outputRange(FeederConstants.kFeederMinOutput, FeederConstants.kFeederMaxOutput);
     feederConfig.closedLoop.feedForward
-        .kA(Constants.Feeder.kFeederVelFF);
+        .kA(FeederConstants.kFeederVelFF);
     feederConfig.closedLoop.maxMotion
         .positionMode(MAXMotionPositionMode.kMAXMotionTrapezoidal)
-        .cruiseVelocity(Constants.Feeder.kFeederMaxVel)
-        .maxAcceleration(Constants.Feeder.kFeederMaxAccel)
-        .allowedProfileError(Constants.Feeder.kFeederAllowedErr);
+        .cruiseVelocity(FeederConstants.kFeederMaxVel)
+        .maxAcceleration(FeederConstants.kFeederMaxAccel)
+        .allowedProfileError(FeederConstants.kFeederAllowedErr);
 
     feeder.configure(
         feederConfig,
@@ -177,7 +178,7 @@ public class Feeder extends SubsystemBase {
       feederSim = SparkMaxSimulation.createVelocitySim(
           feeder,
           DCMotor.getNEO(1),
-          Constants.Feeder.kFeederGearRatio,
+          FeederConstants.kFeederGearRatio,
           0.003 // MOI in kg*m^2 for roller
       );
     }
@@ -271,7 +272,7 @@ public class Feeder extends SubsystemBase {
    * @return The current motor velocity in the requested units
    */
   public double getFeederVel(boolean rpm) {
-    return rpm ? feederEncoder.getVelocity() : Library.rpmToPct(feederEncoder.getVelocity(), Constants.MotorConstants.kNeoFreeSpeedRpm);
+    return rpm ? feederEncoder.getVelocity() : Library.rpmToPct(feederEncoder.getVelocity(), FeederConstants.kFeederMotorFreeSpeedRpm);
   }
 
   /**
@@ -280,7 +281,7 @@ public class Feeder extends SubsystemBase {
    * @return True if the current velocity is within the allowed error of the setpoint, false otherwise
    */
   public boolean onFeederTarget() {
-    return Math.abs(getFeederVel(true) - getFeederSP(true)) < Constants.Feeder.kFeederAllowedErr;
+    return Math.abs(getFeederVel(true) - getFeederSP(true)) < FeederConstants.kFeederAllowedErr;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -23,6 +23,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.constants.IntakeConstants;
 import frc.robot.utils.Library;
 import frc.robot.utils.SparkMaxSimulation;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -33,9 +34,9 @@ public class Intake extends SubsystemBase {
   // Define Intake & Tilt Motors
   // ==============================================================
   private final SparkMax intake = new SparkMax(
-      Constants.CANId.kIntakeIntakeCanId, MotorType.kBrushless);
+      IntakeConstants.kIntakeMotorCanId, MotorType.kBrushless);
   private final SparkMax tilt = new SparkMax(
-      Constants.CANId.kIntakeTiltCanId, MotorType.kBrushless);
+      IntakeConstants.kTiltMotorCanId, MotorType.kBrushless);
 
   private final SparkMaxConfig intakeConfig = new SparkMaxConfig();
   private final SparkMaxConfig tiltConfig = new SparkMaxConfig();
@@ -68,7 +69,7 @@ public class Intake extends SubsystemBase {
 
     public double getVel(boolean rpm) {
       if (rpm) {
-        return (Library.pctToRpm(pct, Constants.MotorConstants.kNeoFreeSpeedRpm));  // * Constants.Intake.kIntakeVelocityFactor);
+        return Library.pctToRpm(pct, IntakeConstants.kIntakeMotorFreeSpeedRpm);
       } else {
         return pct;
       }
@@ -134,24 +135,24 @@ public class Intake extends SubsystemBase {
 
     // Configure Intake motor
     intakeConfig
-        .idleMode(Constants.Intake.kIntakeIdleMode)
-        .smartCurrentLimit(Constants.Intake.kIntakeCurrentLimit)
-        .inverted(Constants.Intake.kIntakeMotorInverted);
+        .idleMode(IntakeConstants.kIntakeIdleMode)
+        .smartCurrentLimit(IntakeConstants.kIntakeCurrentLimit)
+        .inverted(IntakeConstants.kIntakeMotorInverted);
     intakeConfig.encoder
-        .velocityConversionFactor(Constants.Intake.kIntakeVelocityFactor);
+        .velocityConversionFactor(IntakeConstants.kIntakeVelocityFactor);
     intakeConfig.closedLoop
         .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
-        .p(Constants.Intake.kIntakeP)
-        .i(Constants.Intake.kIntakeI)
-        .d(Constants.Intake.kIntakeD)
-        .outputRange(Constants.Intake.kIntakeMinOutput, Constants.Intake.kIntakeMaxOutput);
+        .p(IntakeConstants.kIntakeP)
+        .i(IntakeConstants.kIntakeI)
+        .d(IntakeConstants.kIntakeD)
+        .outputRange(IntakeConstants.kIntakeMinOutput, IntakeConstants.kIntakeMaxOutput);
     intakeConfig.closedLoop.feedForward
-        .kA(Constants.Intake.kVelFF);
+        .kA(IntakeConstants.kVelFF);
     intakeConfig.closedLoop.maxMotion
         .positionMode(MAXMotionPositionMode.kMAXMotionTrapezoidal)
-        .cruiseVelocity(Constants.Intake.kIntakeMaxVel)
-        .maxAcceleration(Constants.Intake.kIntakeMaxAccel)
-        .allowedProfileError(Constants.Intake.kIntakeAllowedErr);
+        .cruiseVelocity(IntakeConstants.kIntakeMaxVel)
+        .maxAcceleration(IntakeConstants.kIntakeMaxAccel)
+        .allowedProfileError(IntakeConstants.kIntakeAllowedErr);
 
     intake.configure(
         intakeConfig,
@@ -160,28 +161,28 @@ public class Intake extends SubsystemBase {
 
     // Configure Tilt motor
     tiltConfig
-        .inverted(Constants.Intake.kTiltMotorInverted)
-        .idleMode(Constants.Intake.kTiltIdleMode)
-        .smartCurrentLimit(Constants.Intake.kTiltCurrentLimit);
+        .inverted(IntakeConstants.kTiltMotorInverted)
+        .idleMode(IntakeConstants.kTiltIdleMode)
+        .smartCurrentLimit(IntakeConstants.kTiltCurrentLimit);
     tiltConfig.absoluteEncoder
-        .zeroOffset(Constants.Intake.kTiltZeroOffset)
-        .zeroCentered(Constants.Intake.kTiltZeroCentered)
-        .inverted(Constants.Intake.kTiltEncoderInverted)
-        .positionConversionFactor(Constants.Intake.kTiltPositionFactor)
-        .velocityConversionFactor(Constants.Intake.kTiltVelocityFactor)
+        .zeroOffset(IntakeConstants.kTiltZeroOffset)
+        .zeroCentered(IntakeConstants.kTiltZeroCentered)
+        .inverted(IntakeConstants.kTiltEncoderInverted)
+        .positionConversionFactor(IntakeConstants.kTiltPositionFactor)
+        .velocityConversionFactor(IntakeConstants.kTiltVelocityFactor)
         .apply(AbsoluteEncoderConfig.Presets.REV_ThroughBoreEncoderV2);
     tiltConfig.closedLoop
         .feedbackSensor(FeedbackSensor.kAbsoluteEncoder)
-        .p(Constants.Intake.kTiltP)
-        .i(Constants.Intake.kTiltI)
-        .d(Constants.Intake.kTiltD)
-        .outputRange(Constants.Intake.kTiltMinOutput, Constants.Intake.kTiltMaxOutput)
-				.positionWrappingEnabled(Constants.Intake.kTiltEncodeWrapping);
+        .p(IntakeConstants.kTiltP)
+        .i(IntakeConstants.kTiltI)
+        .d(IntakeConstants.kTiltD)
+        .outputRange(IntakeConstants.kTiltMinOutput, IntakeConstants.kTiltMaxOutput)
+				.positionWrappingEnabled(IntakeConstants.kTiltEncodeWrapping);
     tiltConfig.closedLoop.maxMotion
         .positionMode(MAXMotionPositionMode.kMAXMotionTrapezoidal)
-        .cruiseVelocity(Constants.Intake.kTiltMaxVel)
-        .maxAcceleration(Constants.Intake.kTiltMaxAccel)
-        .allowedProfileError(Constants.Intake.kTiltAllowedErr);
+        .cruiseVelocity(IntakeConstants.kTiltMaxVel)
+        .maxAcceleration(IntakeConstants.kTiltMaxAccel)
+        .allowedProfileError(IntakeConstants.kTiltAllowedErr);
 
     tilt.configure(
         tiltConfig,
@@ -212,7 +213,7 @@ public class Intake extends SubsystemBase {
       intakeSim = SparkMaxSimulation.createVelocitySim(
           intake,
           DCMotor.getNEO(1),
-          Constants.Intake.kIntakeGearRatio,
+          IntakeConstants.kIntakeGearRatio,
           0.005 // MOI in kg*m^2
       );
 
@@ -220,7 +221,7 @@ public class Intake extends SubsystemBase {
       tiltSim = SparkMaxSimulation.createPositionSim(
           tilt,
           DCMotor.getNEO(1),
-          Constants.Intake.kTiltGearRatio,
+          IntakeConstants.kTiltGearRatio,
           0.5, // arm length in meters
           TiltSP.STOW.getPos(), // min angle
           TiltSP.DEPLOY.getPos(), // max angle
@@ -341,7 +342,7 @@ public class Intake extends SubsystemBase {
    * @return The current intake velocity in the requested units.
    */
   public double getIntakeVel(boolean rpm) {
-    return rpm ? intakeEncoder.getVelocity() : Library.rpmToPct(intakeEncoder.getVelocity(), Constants.MotorConstants.kNeoFreeSpeedRpm);
+    return rpm ? intakeEncoder.getVelocity() : Library.rpmToPct(intakeEncoder.getVelocity(), IntakeConstants.kIntakeMotorFreeSpeedRpm);
   }
 
   /**
@@ -350,7 +351,7 @@ public class Intake extends SubsystemBase {
    * @return True if the intake is at the target velocity, false otherwise.
    */
   public boolean onIntakeTarget() {
-    return Math.abs(getIntakeVel(true) - getIntakeSP(true)) < Constants.Intake.kIntakeAllowedErr;
+    return Math.abs(getIntakeVel(true) - getIntakeSP(true)) < IntakeConstants.kIntakeAllowedErr;
   }
 
   /**
@@ -397,6 +398,6 @@ public class Intake extends SubsystemBase {
    * @return True if the tilt is at the target position, false otherwise.
    */
   public boolean onTiltTarget() {
-    return Math.abs(getTiltPos() - getTiltSP().getPos()) < Constants.Intake.kTiltAllowedErr;
+    return Math.abs(getTiltPos() - getTiltSP().getPos()) < IntakeConstants.kTiltAllowedErr;
   }
 }

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -27,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.constants.ShooterConstants;
 import frc.robot.utils.Library;
 import frc.robot.utils.ShooterBallistics;
 import frc.robot.utils.SparkMaxSimulation;
@@ -37,11 +38,11 @@ public class Shooter extends SubsystemBase {
 	// Define Shooter & Tilt Motors
 	// ==============================================================
 	private final SparkFlex leftShooter = new SparkFlex(
-			Constants.CANId.kShooterLeftCanId, MotorType.kBrushless);
+			ShooterConstants.kLeftShooterCanId, MotorType.kBrushless);
 	private final SparkFlex rightShooter = new SparkFlex(
-			Constants.CANId.kShooterRightCanId, MotorType.kBrushless);
+			ShooterConstants.kRightShooterCanId, MotorType.kBrushless);
 	private final SparkMax tilt = new SparkMax(
-			Constants.CANId.kShooterTiltCanId, MotorType.kBrushless);
+			ShooterConstants.kTiltMotorCanId, MotorType.kBrushless);
 
 	private final SparkFlexConfig leftConfig = new SparkFlexConfig();
 	private final SparkFlexConfig rightConfig = new SparkFlexConfig();
@@ -77,7 +78,7 @@ public class Shooter extends SubsystemBase {
 
 		public double getVel(boolean rpm) {
 			if (rpm) {
-				return Library.pctToRpm(pct, Constants.MotorConstants.kVortexFreeSpeedRpm);
+				return Library.pctToRpm(pct, ShooterConstants.kShooterMotorFreeSpeedRpm);
 			} else {
 				return pct;
 			}
@@ -161,24 +162,24 @@ public class Shooter extends SubsystemBase {
 
 		// Configure Left Shooter motor
 		leftConfig
-				.inverted(Constants.Shooter.kLeftMotorInverted)
-				.idleMode(Constants.Shooter.kLeftIdleMode)
-				.smartCurrentLimit(Constants.Shooter.kLeftCurrentLimit);
+				.inverted(ShooterConstants.kLeftMotorInverted)
+				.idleMode(ShooterConstants.kLeftIdleMode)
+				.smartCurrentLimit(ShooterConstants.kLeftCurrentLimit);
 		leftConfig.encoder
-				.velocityConversionFactor(Constants.Shooter.kShooterVelocityFactor);
+				.velocityConversionFactor(ShooterConstants.kShooterVelocityFactor);
 		leftConfig.closedLoop
 				.feedbackSensor(FeedbackSensor.kPrimaryEncoder)
-				.p(Constants.Shooter.kP)
-				.i(Constants.Shooter.kI)
-				.d(Constants.Shooter.kD)
-				.outputRange(Constants.Shooter.kMinOutput, Constants.Shooter.kMaxOutput);
+				.p(ShooterConstants.kP)
+				.i(ShooterConstants.kI)
+				.d(ShooterConstants.kD)
+				.outputRange(ShooterConstants.kMinOutput, ShooterConstants.kMaxOutput);
 		leftConfig.closedLoop.feedForward
-				.kA(Constants.Shooter.kVelFF);
+				.kA(ShooterConstants.kVelFF);
 		leftConfig.closedLoop.maxMotion
 				.positionMode(MAXMotionPositionMode.kMAXMotionTrapezoidal)
-				.cruiseVelocity(Constants.Shooter.kMaxVel)
-				.maxAcceleration(Constants.Shooter.kMaxAccel)
-				.allowedProfileError(Constants.Shooter.kAllowedErr);
+				.cruiseVelocity(ShooterConstants.kMaxVel)
+				.maxAcceleration(ShooterConstants.kMaxAccel)
+				.allowedProfileError(ShooterConstants.kAllowedErr);
 
 		leftShooter.configure(leftConfig,
 				com.revrobotics.ResetMode.kResetSafeParameters,
@@ -187,7 +188,7 @@ public class Shooter extends SubsystemBase {
 		// Configure Right Shooter motor
 		rightConfig
 				.follow(leftShooter, true)
-				.inverted(Constants.Shooter.kRightMotorInverted);
+				.inverted(ShooterConstants.kRightMotorInverted);
 
 		rightShooter.configure(rightConfig,
 				com.revrobotics.ResetMode.kResetSafeParameters,
@@ -195,28 +196,28 @@ public class Shooter extends SubsystemBase {
 
 		// Configure Tilt motor
 		tiltConfig
-				.inverted(Constants.Shooter.kTiltMotorInverted)
-				.idleMode(Constants.Shooter.kTiltIdleMode)
-				.smartCurrentLimit(Constants.Shooter.kTiltCurrentLimit);
+				.inverted(ShooterConstants.kTiltMotorInverted)
+				.idleMode(ShooterConstants.kTiltIdleMode)
+				.smartCurrentLimit(ShooterConstants.kTiltCurrentLimit);
 		tiltConfig.absoluteEncoder
-				.zeroOffset(Constants.Shooter.kTiltZeroOffset)
-				.zeroCentered(Constants.Shooter.kTiltZeroCentered)
-				.inverted(Constants.Shooter.kTiltEncoderInverted)
-				.positionConversionFactor(Constants.Shooter.kTiltPositionFactor)
-				.velocityConversionFactor(Constants.Shooter.kTiltVelocityFactor)
+				.zeroOffset(ShooterConstants.kTiltZeroOffset)
+				.zeroCentered(ShooterConstants.kTiltZeroCentered)
+				.inverted(ShooterConstants.kTiltEncoderInverted)
+				.positionConversionFactor(ShooterConstants.kTiltPositionFactor)
+				.velocityConversionFactor(ShooterConstants.kTiltVelocityFactor)
 				.apply(AbsoluteEncoderConfig.Presets.REV_ThroughBoreEncoderV2);
 		tiltConfig.closedLoop
 				.feedbackSensor(FeedbackSensor.kAbsoluteEncoder)
-				.p(Constants.Shooter.kPosP)
-				.i(Constants.Shooter.kPosI)
-				.d(Constants.Shooter.kPosD)
-				.outputRange(Constants.Shooter.kPosMinOutput, Constants.Shooter.kPosMaxOutput)
-				.positionWrappingEnabled(Constants.Shooter.kTiltEncodeWrapping);
+				.p(ShooterConstants.kPosP)
+				.i(ShooterConstants.kPosI)
+				.d(ShooterConstants.kPosD)
+				.outputRange(ShooterConstants.kPosMinOutput, ShooterConstants.kPosMaxOutput)
+				.positionWrappingEnabled(ShooterConstants.kTiltEncodeWrapping);
 		tiltConfig.closedLoop.maxMotion
 				.positionMode(MAXMotionPositionMode.kMAXMotionTrapezoidal)
-				.cruiseVelocity(Constants.Shooter.kPosMaxVel)
-				.maxAcceleration(Constants.Shooter.kPosMaxAccel)
-				.allowedProfileError(Constants.Shooter.kPosAllowedErr);
+				.cruiseVelocity(ShooterConstants.kPosMaxVel)
+				.maxAcceleration(ShooterConstants.kPosMaxAccel)
+				.allowedProfileError(ShooterConstants.kPosAllowedErr);
 
 		tilt.configure(tiltConfig,
 				com.revrobotics.ResetMode.kResetSafeParameters,
@@ -256,7 +257,7 @@ public class Shooter extends SubsystemBase {
 			tiltSim = SparkMaxSimulation.createPositionSim(
 					tilt,
 					DCMotor.getNEO(1),
-					Constants.Shooter.kTiltGearRatio,
+					ShooterConstants.kTiltGearRatio,
 					0.6, // arm length in meters
 					TiltSP.LOW.getPos(), // min angle
 					TiltSP.HI.getPos(), // max angle
@@ -359,7 +360,7 @@ public class Shooter extends SubsystemBase {
 		// Gives you live visibility of what the solver wants to do,
 		// without actually commanding anything unless you call autoShoot().
 		if (drivetrain != null) {
-			var auto = ShooterBallistics.solveStationary(drivetrain.getDistToHub(), Constants.Shooter.kBallisticsCoefficient);
+			var auto = ShooterBallistics.solveStationary(drivetrain.getDistToHub(), ShooterConstants.kBallisticsCoefficient);
 			sbAutoFeasible.setBoolean(auto.feasible());
 			sbAutoAngleDeg
 					.setDouble(Library.SBFormat(auto.feasible() ? auto.angleDeg() : ShooterBallistics.kMinAngleDeg));
@@ -394,7 +395,7 @@ public class Shooter extends SubsystemBase {
 		if (drivetrain == null)
 			return 0.0;
 		double distToHubM = drivetrain.getDistToHub(); // already returns meters
-		var sp = ShooterBallistics.solveStationary(distToHubM, Constants.Shooter.kBallisticsCoefficient);
+		var sp = ShooterBallistics.solveStationary(distToHubM, ShooterConstants.kBallisticsCoefficient);
 
 		if (!sp.feasible())
 			return 0.0; // or hold last good value if you prefer
@@ -418,7 +419,7 @@ public class Shooter extends SubsystemBase {
 		if (drivetrain == null)
 			return ShooterBallistics.kMinAngleDeg;
 		double distToHubM = drivetrain.getDistToHub();
-		var sp = ShooterBallistics.solveStationary(distToHubM, Constants.Shooter.kBallisticsCoefficient);
+		var sp = ShooterBallistics.solveStationary(distToHubM, ShooterConstants.kBallisticsCoefficient);
 
 		double angleDeg = sp.feasible()
 				? sp.angleDeg()
@@ -494,7 +495,7 @@ public class Shooter extends SubsystemBase {
 	 */
 	public double getShooterSP(boolean rpm) {
 		if (shooterSpIsCustom) {
-			return rpm ? shooterSPDbl : Library.rpmToPct(shooterSPDbl, Constants.MotorConstants.kVortexFreeSpeedRpm);
+			return rpm ? shooterSPDbl : Library.rpmToPct(shooterSPDbl, ShooterConstants.kShooterMotorFreeSpeedRpm);
 
 		}
 		return shooterSP.getVel(rpm);
@@ -529,7 +530,7 @@ public class Shooter extends SubsystemBase {
 	 * @return The current shooter velocity in the requested units
 	 */
 	public double getShooterVel(boolean rpm) {
-		return rpm ? leftEncoder.getVelocity() : Library.rpmToPct(leftEncoder.getVelocity(), Constants.MotorConstants.kVortexFreeSpeedRpm);
+		return rpm ? leftEncoder.getVelocity() : Library.rpmToPct(leftEncoder.getVelocity(), ShooterConstants.kShooterMotorFreeSpeedRpm);
 	}
 
 	/**
@@ -634,7 +635,7 @@ public class Shooter extends SubsystemBase {
 	 */
 	public boolean onTiltTarget() {
 		double target = tiltSpIsCustom ? tiltSPDbl : tiltSP.getPos();
-		return Math.abs(getTiltPos() - target) < Constants.Shooter.kPosAllowedErr;
+		return Math.abs(getTiltPos() - target) < ShooterConstants.kPosAllowedErr;
 	}
 
 	/**
@@ -644,6 +645,6 @@ public class Shooter extends SubsystemBase {
 	 * @return True if within tolerance of target velocity, false otherwise
 	 */
 	public boolean onShooterTarget() {
-		return Math.abs(getShooterVel(true) - getShooterSP(true)) < Constants.Shooter.kAllowedErr;
+		return Math.abs(getShooterVel(true) - getShooterSP(true)) < ShooterConstants.kAllowedErr;
 	}
 }

--- a/src/main/java/frc/robot/subsystems/Vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionConstants.java
@@ -15,6 +15,23 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 
 public class VisionConstants {
+    public static final double kXP = 0.6;
+    public static final double kXI = 0.0;
+    public static final double kXD = 0.0;
+    public static final double kXTolerance = 0.1;
+
+    public static final double kYP = 0.6;
+    public static final double kYI = 0.0;
+    public static final double kYD = 0.0;
+    public static final double kYTolerance = 0.1;
+
+    public static final double kRP = 0.03;
+    public static final double kRI = 0.0;
+    public static final double kRD = 0.0;
+    public static final double kRTolerance = 0.1;
+    public static final double kRMin = 0.0;
+    public static final double kRMax = 360.0;
+
     // AprilTag layout
     public static AprilTagFieldLayout aprilTagLayout = AprilTagFieldLayout.loadField(AprilTagFields.kDefaultField);
 

--- a/src/test/java/frc/robot/subsystems/ClimberTest.java
+++ b/src/test/java/frc/robot/subsystems/ClimberTest.java
@@ -1,0 +1,50 @@
+package frc.robot.subsystems;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import frc.robot.subsystems.Climber.ClimberSP;
+import frc.robot.subsystems.Climber.HookSP;
+
+public class ClimberTest {
+
+    private final Climber climber = new Climber();
+
+    @Test
+    @DisplayName("Climber And Hook Setpoints")
+    void testSetpoints() {
+        climber.setClimberSP(ClimberSP.STOW);
+        assertEquals("STOW", climber.getClimberSP().name());
+        assertEquals(ClimberSP.STOW.getValue(), climber.getClimberSP().getValue());
+
+        climber.setClimberSP(ClimberSP.LVLAUTON);
+        assertEquals("LVLAUTON", climber.getClimberSP().name());
+        assertEquals(ClimberSP.LVLAUTON.getValue(), climber.getClimberSP().getValue());
+
+        climber.setClimberSP(ClimberSP.LVL1);
+        assertEquals("LVL1", climber.getClimberSP().name());
+        assertEquals(ClimberSP.LVL1.getValue(), climber.getClimberSP().getValue());
+
+        climber.setClimberSP(ClimberSP.LVL2);
+        assertEquals("LVL2", climber.getClimberSP().name());
+        assertEquals(ClimberSP.LVL2.getValue(), climber.getClimberSP().getValue());
+
+        climber.setClimberSP(ClimberSP.LVL3);
+        assertEquals("LVL3", climber.getClimberSP().name());
+        assertEquals(ClimberSP.LVL3.getValue(), climber.getClimberSP().getValue());
+        
+        climber.setHookSP(HookSP.STOW);
+        assertEquals("STOW", climber.getHookSP().name());
+        assertEquals(HookSP.STOW.getSpd(), climber.getHookSP().getSpd());
+
+        climber.setHookSP(HookSP.STOP);
+        assertEquals("STOP", climber.getHookSP().name());
+        assertEquals(HookSP.STOP.getSpd(), climber.getHookSP().getSpd());
+
+        climber.setHookSP(HookSP.DEPLOY);
+        assertEquals("DEPLOY", climber.getHookSP().name());
+        assertEquals(HookSP.DEPLOY.getSpd(), climber.getHookSP().getSpd());
+    }
+}

--- a/src/test/java/frc/robot/subsystems/FeederTest.java
+++ b/src/test/java/frc/robot/subsystems/FeederTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import frc.robot.Constants;
+import frc.robot.constants.FeederConstants;
 import frc.robot.subsystems.Feeder.FeederSP;
 
 public class FeederTest {
@@ -19,22 +19,22 @@ public class FeederTest {
         assertEquals("OFF", feeder.getFeederSP().name());
         assertEquals(FeederSP.OFF.getVel(false), feeder.getFeederSP(false));
         assertEquals(FeederSP.OFF.getVel(true), feeder.getFeederSP(true));
-        assertEquals(FeederSP.OFF.getVel(true), feeder.getFeederSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(FeederSP.OFF.getVel(true), feeder.getFeederSP(false) * FeederConstants.kFeederMotorFreeSpeedRpm / 100.0);
         feeder.setFeederSP(FeederSP.HI);
         assertEquals("HI", feeder.getFeederSP().name());
         assertEquals(FeederSP.HI.getVel(false), feeder.getFeederSP(false));
         assertEquals(FeederSP.HI.getVel(true), feeder.getFeederSP(true));
-        assertEquals(FeederSP.HI.getVel(true), feeder.getFeederSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(FeederSP.HI.getVel(true), feeder.getFeederSP(false) * FeederConstants.kFeederMotorFreeSpeedRpm / 100.0);
         feeder.setFeederSP(FeederSP.MED);
         assertEquals("MED", feeder.getFeederSP().name());
         assertEquals(FeederSP.MED.getVel(false), feeder.getFeederSP(false));
         assertEquals(FeederSP.MED.getVel(true), feeder.getFeederSP(true));
-        assertEquals(FeederSP.MED.getVel(true), feeder.getFeederSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(FeederSP.MED.getVel(true), feeder.getFeederSP(false) * FeederConstants.kFeederMotorFreeSpeedRpm / 100.0);
         feeder.setFeederSP(FeederSP.LOW);
         assertEquals("LOW", feeder.getFeederSP().name());
         assertEquals(FeederSP.LOW.getVel(false), feeder.getFeederSP(false));
         assertEquals(FeederSP.LOW.getVel(true), feeder.getFeederSP(true));
-        assertEquals(FeederSP.LOW.getVel(true), feeder.getFeederSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(FeederSP.LOW.getVel(true), feeder.getFeederSP(false) * FeederConstants.kFeederMotorFreeSpeedRpm / 100.0);
     }
 
 

--- a/src/test/java/frc/robot/subsystems/IntakeTest.java
+++ b/src/test/java/frc/robot/subsystems/IntakeTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import frc.robot.Constants;
+import frc.robot.constants.IntakeConstants;
 import frc.robot.subsystems.Intake.IntakeSP;
 
 public class IntakeTest {
@@ -19,22 +19,22 @@ public class IntakeTest {
         assertEquals("OFF", intake.getIntakeSP().name());
         assertEquals(IntakeSP.OFF.getVel(false), intake.getIntakeSP(false));
         assertEquals(IntakeSP.OFF.getVel(true), intake.getIntakeSP(true));
-        assertEquals(IntakeSP.OFF.getVel(true), intake.getIntakeSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(IntakeSP.OFF.getVel(true), intake.getIntakeSP(false) * IntakeConstants.kIntakeMotorFreeSpeedRpm / 100.0);
         intake.setIntakeSP(IntakeSP.HI);
         assertEquals("HI", intake.getIntakeSP().name());
         assertEquals(IntakeSP.HI.getVel(false), intake.getIntakeSP(false));
         assertEquals(IntakeSP.HI.getVel(true), intake.getIntakeSP(true));
-        assertEquals(IntakeSP.HI.getVel(true), intake.getIntakeSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(IntakeSP.HI.getVel(true), intake.getIntakeSP(false) * IntakeConstants.kIntakeMotorFreeSpeedRpm / 100.0);
         intake.setIntakeSP(IntakeSP.MED);
         assertEquals("MED", intake.getIntakeSP().name());
         assertEquals(IntakeSP.MED.getVel(false), intake.getIntakeSP(false));
         assertEquals(IntakeSP.MED.getVel(true), intake.getIntakeSP(true));
-        assertEquals(IntakeSP.MED.getVel(true), intake.getIntakeSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(IntakeSP.MED.getVel(true), intake.getIntakeSP(false) * IntakeConstants.kIntakeMotorFreeSpeedRpm / 100.0);
         intake.setIntakeSP(IntakeSP.LOW);
         assertEquals("LOW", intake.getIntakeSP().name());
         assertEquals(IntakeSP.LOW.getVel(false), intake.getIntakeSP(false));
         assertEquals(IntakeSP.LOW.getVel(true), intake.getIntakeSP(true));
-        assertEquals(IntakeSP.LOW.getVel(true), intake.getIntakeSP(false) * Constants.MotorConstants.kNeoFreeSpeedRpm / 100.0);
+        assertEquals(IntakeSP.LOW.getVel(true), intake.getIntakeSP(false) * IntakeConstants.kIntakeMotorFreeSpeedRpm / 100.0);
     }
 
 

--- a/src/test/java/frc/robot/subsystems/ShooterTest.java
+++ b/src/test/java/frc/robot/subsystems/ShooterTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import frc.robot.Constants;
+import frc.robot.constants.ShooterConstants;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.Shooter.ShooterSP;
 import frc.robot.subsystems.Shooter.TiltSP;
@@ -23,25 +23,25 @@ public class ShooterTest {
                 assertEquals(ShooterSP.OFF.getVel(false), shooter.getShooterSP(false));
                 assertEquals(ShooterSP.OFF.getVel(true), shooter.getShooterSP(true));
                 assertEquals(ShooterSP.OFF.getVel(true),
-                                shooter.getShooterSP(false) / 100.0 * Constants.MotorConstants.kVortexFreeSpeedRpm);
+                                shooter.getShooterSP(false) / 100.0 * ShooterConstants.kShooterMotorFreeSpeedRpm);
                 shooter.setShooterSP(ShooterSP.HI);
                 assertEquals("HI", shooter.getShooterSPName());
                 assertEquals(ShooterSP.HI.getVel(false), shooter.getShooterSP(false));
                 assertEquals(ShooterSP.HI.getVel(true), shooter.getShooterSP(true));
                 assertEquals(ShooterSP.HI.getVel(true),
-                                shooter.getShooterSP(false) / 100.0 * Constants.MotorConstants.kVortexFreeSpeedRpm);
+                                shooter.getShooterSP(false) / 100.0 * ShooterConstants.kShooterMotorFreeSpeedRpm);
                 shooter.setShooterSP(ShooterSP.MED);
                 assertEquals("MED", shooter.getShooterSPName());
                 assertEquals(ShooterSP.MED.getVel(false), shooter.getShooterSP(false));
                 assertEquals(ShooterSP.MED.getVel(true), shooter.getShooterSP(true));
                 assertEquals(ShooterSP.MED.getVel(true),
-                                shooter.getShooterSP(false) / 100.0 * Constants.MotorConstants.kVortexFreeSpeedRpm);
+                                shooter.getShooterSP(false) / 100.0 * ShooterConstants.kShooterMotorFreeSpeedRpm);
                 shooter.setShooterSP(ShooterSP.LOW);
                 assertEquals("LOW", shooter.getShooterSPName());
                 assertEquals(ShooterSP.LOW.getVel(false), shooter.getShooterSP(false));
                 assertEquals(ShooterSP.LOW.getVel(true), shooter.getShooterSP(true));
                 assertEquals(ShooterSP.LOW.getVel(true),
-                                shooter.getShooterSP(false) / 100.0 * Constants.MotorConstants.kVortexFreeSpeedRpm);
+                                shooter.getShooterSP(false) / 100.0 * ShooterConstants.kShooterMotorFreeSpeedRpm);
 
                 shooter.setShooterSPDbl(1000.0);
                 assertEquals("Velocity", shooter.getShooterSPName());

--- a/src/test/java/frc/robot/subsystems/Vision/VisionTest.java
+++ b/src/test/java/frc/robot/subsystems/Vision/VisionTest.java
@@ -1,0 +1,102 @@
+package frc.robot.subsystems.Vision;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import frc.robot.subsystems.Vision.VisionIO.PoseObservation;
+import frc.robot.subsystems.Vision.VisionIO.PoseObservationType;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class VisionTest {
+
+    static class FakeVisionIO implements VisionIO {
+        private final PoseObservation[] observations;
+
+        FakeVisionIO(PoseObservation... observations) {
+            this.observations = observations;
+        }
+
+        @Override
+        public void updateInputs(VisionIOInputs inputs) {
+            inputs.connected = true;
+            inputs.poseObservations = observations;
+            inputs.tagIds = new int[] { 1 };
+        }
+    }
+
+    @Test
+    @DisplayName("Rejects Zero Tag Observation")
+    void rejectsZeroTagObservation() {
+        AtomicInteger callCount = new AtomicInteger();
+
+        Vision vision = new Vision(
+                (Pose2d pose, double timestamp, Matrix<N3, N1> stdDevs) -> callCount.incrementAndGet(),
+                new FakeVisionIO(
+                        new PoseObservation(
+                                1.0,
+                                new Pose3d(),
+                                0.0,
+                                0,
+                                1.0,
+                                PoseObservationType.PHOTONVISION)));
+
+        vision.periodic();
+
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    @DisplayName("Rejects High Ambiguity Single Tag")
+    void rejectsHighAmbiguitySingleTag() {
+        AtomicInteger callCount = new AtomicInteger();
+
+        Vision vision = new Vision(
+                (Pose2d pose, double timestamp, Matrix<N3, N1> stdDevs) -> callCount.incrementAndGet(),
+                new FakeVisionIO(
+                        new PoseObservation(
+                                1.0,
+                                new Pose3d(),
+                                VisionConstants.maxAmbiguity + 0.01,
+                                1,
+                                1.0,
+                                PoseObservationType.PHOTONVISION)));
+
+        vision.periodic();
+
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    @DisplayName("Accepts Valid Observation")
+    void acceptsValidObservation() {
+        AtomicInteger callCount = new AtomicInteger();
+        AtomicReference<Pose2d> acceptedPose = new AtomicReference<>();
+
+        Pose3d pose = new Pose3d(1.0, 1.0, 0.0, new edu.wpi.first.math.geometry.Rotation3d());
+        Vision vision = new Vision(
+                (Pose2d accepted, double timestamp, Matrix<N3, N1> stdDevs) -> {
+                    callCount.incrementAndGet();
+                    acceptedPose.set(accepted);
+                },
+                new FakeVisionIO(
+                        new PoseObservation(
+                                1.0,
+                                pose,
+                                0.0,
+                                2,
+                                1.0,
+                                PoseObservationType.PHOTONVISION)));
+
+        vision.periodic();
+
+        assertEquals(1, callCount.get());
+        assertEquals(pose.toPose2d(), acceptedPose.get());
+    }
+}


### PR DESCRIPTION
## Summary

This PR continues the constants cleanup by moving subsystem-specific and command-level drivetrain configuration out of the legacy shared `Constants` structure and into dedicated constants classes.

It updates the feeder, intake, shooter, and climber subsystems to use their matching constants files, extracts command-layer drivetrain constants into `CommandSwerveDrivetrainConstants`, and reuses the existing `VisionConstants` file for vision tuning/config instead of keeping a separate `Constants.Vision` block. `Constants.java` is now reduced to shared robot-wide values only.

## Changes

- Updated `Feeder`, `Intake`, `Shooter`, and `Climber` to use:
  - `FeederConstants`
  - `IntakeConstants`
  - `ShooterConstants`
  - `ClimberConstants`
- Added subsystem-owned motor free-speed constants for:
  - feeder
  - intake
  - shooter
- Updated feeder/intake/shooter percent-to-RPM and RPM-to-percent conversion logic to use subsystem constants instead of legacy global motor constants
- Extracted command-layer drivetrain values into:
  - `CommandSwerveDrivetrainConstants`
- Updated `CommandSwerveDrivetrain` to use extracted drivetrain constants for:
  - sim loop timing
  - alliance perspective rotations
  - hub/start poses
  - path-following PID values
- Reused and expanded the existing `VisionConstants` file to hold the remaining vision tuning values that had still been living in `Constants.java`
- Trimmed `Constants.java` down to shared/global constants only
- Updated subsystem tests to assert against the new constants locations
- Added a narrow `ClimberTest`
- Added a narrow `VisionTest` for vision observation filtering behavior

## Why

The project was in a partially migrated state where some subsystem configuration had already moved into dedicated constants files, but parts of the implementation, tests, and drivetrain/vision configuration still relied on the older shared `Constants` layout. This PR makes that organization more consistent and keeps configuration owned locally by the subsystem or feature that actually uses it.

## Testing

Ran successfully:

- `./gradlew test --tests frc.robot.subsystems.FeederTest`
- `./gradlew test --tests frc.robot.subsystems.IntakeTest`
- `./gradlew test --tests frc.robot.subsystems.ShooterTest`
- `./gradlew test --tests frc.robot.subsystems.ClimberTest`
- `./gradlew test --tests frc.robot.subsystems.Vision.VisionTest`
- `./gradlew test`

## Notes

This PR is intended to be a refactor for constants ownership, organization, and test coverage only. No behavior changes or public API changes are intended.
