### PR TITLE
Refactor: switch power distribution from PDH to PDP

### DIFF
--- a/.gradle/buildOutputCleanup/cache.properties
+++ b/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Tue Feb 24 20:11:02 EST 2026
+#Fri Mar 13 19:56:35 EDT 2026
 gradle.version=8.11

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Java robot code for the 2026 FRC game REBUILT
     * (4x) Krakan 60 - Drive motor
     * (4x) Krakan 44 - Turn motor
         * CANEncoders
-
+* Power Distribution
+    * (1x) CTRE PDP
+    
 **2. Intake**
 * Motors / Encoders
     * (1x) NEO - Intake

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -37,8 +37,8 @@ public final class Constants {
   }
 
   public static final class CANId {
-    public static final int kPDHCanID = 1;
-    public static final int kServoHubCanId = 2;
+    public static final int kPDPCanID = 1;
+    public static final int kServoHubCanId = 0;
 
     public static final int kClimber1CanId = 40;
     public static final int kClimber2CanId = 41;

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -74,8 +74,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
     RobotConfig config = null;
 
-    private PowerDistribution pdh = new PowerDistribution(CANId.kPDHCanID, ModuleType.kRev);
-
+    private PowerDistribution pdp = new PowerDistribution(CANId.kPDPCanID, ModuleType.kCTRE);
+ 
     /*
      * SysId routine for characterizing translation. This is used to find PID gains
      * for the drive motors.
@@ -188,8 +188,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         m_field.setRobotPose(CommandSwerveDrivetrainConstants.kStartPose);
         SmartDashboard.putData("Field", m_field);
 
-        configPDH();
-        configPDH();
+        configPDP();
         configPigeon();
         setupAutoBuilder();
     }
@@ -221,8 +220,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         m_field.setRobotPose(CommandSwerveDrivetrainConstants.kStartPose);
         SmartDashboard.putData("Field", m_field);
 
-        configPDH();
-        configPDH();
+        configPDP();
         configPigeon();
         setupAutoBuilder();
     }
@@ -269,8 +267,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         m_field.setRobotPose(CommandSwerveDrivetrainConstants.kStartPose);
         SmartDashboard.putData("Field", m_field);
 
-        configPDH();
-        configPDH();
+        configPDP();
         configPigeon();
         setupAutoBuilder();
     }
@@ -415,9 +412,9 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
     }
 
-    private void configPDH() {
-        // Initialize Rev PDH
-        pdh.clearStickyFaults();
+    private void configPDP() {
+        // Clear sticky faults on the CTRE PDP during startup
+        pdp.clearStickyFaults();
     }
 
     private void configPigeon() {
@@ -471,16 +468,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         }
     }
 
-    public PowerDistribution getPDH() {
-        return pdh;
-    }
-
-    public void setChannelOn() {
-        pdh.setSwitchableChannel(true);
-    }
-
-    public void setChannelOff() {
-        pdh.setSwitchableChannel(false);
+    public PowerDistribution getPDP() {
+        return pdp;
     }
 
     public Pose2d getPose() {


### PR DESCRIPTION
This PR updates the robot code to use a CTRE PDP instead of a REV PDH.

- It changes the power distribution CAN ID and module type
- Removes the unsupported REV switchable-channel behavior
- Aligns PDP-related naming in the drivetrain code
- Updates the README to reflect the chassis hardware change