### PR TITLE
fix: update shooter and intake tilt for direct-output hardware

### DIFF
--- a/src/main/java/frc/robot/constants/IntakeConstants.java
+++ b/src/main/java/frc/robot/constants/IntakeConstants.java
@@ -43,12 +43,10 @@ public final class IntakeConstants {
 
 //	public static final double kTiltTolerance = 1.0; // degrees
 
-  public static final double kTiltGearRatio = (Constants.GearBox.Max5 * Constants.GearBox.Max5);
+  public static final double kTiltGearRatio = 1.0; // direct output, no extra belt reduction
 
-  
-	// IMPORTANT: Through-bore encoder is mounted on OUTPUT SHAFT, not motor shaft!
-	// Position factor converts OUTPUT shaft rotations to degrees
-	// 1 output rotation = 360 degrees (no gear ratio needed)
+	// IMPORTANT: Through-bore encoder is mounted on the geared-down OUTPUT SHAFT.
+	// Position factor converts output shaft rotations directly to degrees.
   public static final double kTiltPositionFactor = 360.0; // degrees per output rotation
   public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0; // degrees per second
 

--- a/src/main/java/frc/robot/constants/ShooterConstants.java
+++ b/src/main/java/frc/robot/constants/ShooterConstants.java
@@ -40,12 +40,11 @@ public final class ShooterConstants {
 
   // Position is returned in native units of rotations and will be multiplied by
 	// this conversion factor.
-  public static final double kTiltGearRatio = 3.0;  // 3.0 is pully ratio
+  public static final double kTiltGearRatio = 1.0; // direct output, no extra belt reduction
 
-	// IMPORTANT: Through-bore encoder is mounted on OUTPUT SHAFT, not motor shaft!
-	// Position factor converts OUTPUT shaft rotations to degrees
-	// 1 output rotation = 360 degrees (no gear ratio needed)
-  public static final double kTiltPositionFactor = 360.0 / kTiltGearRatio; // degrees per output rotation
+	// IMPORTANT: Through-bore encoder is mounted on the geared-down OUTPUT SHAFT.
+	// Position factor converts output shaft rotations directly to degrees.
+  public static final double kTiltPositionFactor = 360.0; // degrees per output rotation
   public static final double kTiltVelocityFactor = kTiltPositionFactor / 60.0; // degrees per second
 
   public static final double kP = 0.0002; // maxmotion 0.025;


### PR DESCRIPTION
## Summary

This PR updates the shooter and intake tilt configuration to match the new direct-output hardware setup.

The code no longer assumes an extra 3:1 belt stage for tilt, and instead treats the absolute encoder as being mounted directly on the geared-down output shaft. This keeps tilt angle conversion and simulation aligned with the current mechanical design.

## Changes

- Updated shooter tilt constants for direct-output hardware
- Updated intake tilt constants to match the same direct-output assumption
- Set tilt gear ratio modeling to `1.0` for both subsystems
- Updated shooter tilt position conversion to `360.0` degrees per output rotation
- Kept tilt velocity conversion derived from the updated position factor
- Updated comments to reflect the new hardware layout

## Why

The shooter tilt no longer has the old 3:1 belt stage, so the previous conversion math would under-report the real output motion. This change makes the software match the actual hardware and keeps the intake tilt modeling consistent with the same direct-output assumption.

## Testing

- `./gradlew test --tests frc.robot.subsystems.ShooterTest --tests frc.robot.subsystems.IntakeTest`
- `./gradlew test`

## Notes

This PR only updates tilt hardware modeling and conversion assumptions. It does not change zero offsets, inversions, setpoints, or PID gains.
